### PR TITLE
Add support for appsettings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,12 @@ on:
         description: "Publish workflow artifacts"
         type: boolean
         default: false
-      environment:
-        description: "Environment to deploy to"
+      settings_file:
+        description: "The filename of the appsettings file"
         type: string
-        default: "dev"
+
+  pull_request:
+    branches: [ main ]
 
 jobs:
   shifty-build:
@@ -18,7 +20,7 @@ jobs:
     uses: ./.github/workflows/shifty-build.yml
     with:
       publish_artifacts: ${{ inputs.publish_artifacts }}
-      environment: ${{ inputs.environment }}
+      settings_file: ${{ inputs.settings_file }}
     secrets: inherit
 
   infra-build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,10 @@ on:
         description: "Publish workflow artifacts"
         type: boolean
         default: false
+      environment:
+        description: "Environment to deploy to"
+        type: string
+        default: "dev"
 
 jobs:
   shifty-build:
@@ -14,6 +18,7 @@ jobs:
     uses: ./.github/workflows/shifty-build.yml
     with:
       publish_artifacts: ${{ inputs.publish_artifacts }}
+      environment: ${{ inputs.environment }}
     secrets: inherit
 
   infra-build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,6 @@ on:
         description: "The filename of the appsettings file"
         type: string
 
-  pull_request:
-    branches: [ main ]
-
 jobs:
   shifty-build:
     name: Build webapp

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -11,3 +11,4 @@ jobs:
     secrets: inherit
     with:
       environment: dev
+      settings_file: "dev.appsettings.json"

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -10,3 +10,4 @@ jobs:
     secrets: inherit
     with:
       environment: prd
+      settings_file: "prd.appsettings.json"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       publish_artifacts: true
+      environment: ${{ inputs.environment }}
     secrets: inherit
 
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,10 @@ on:
         type: string
         required: true
         description: "Target Environment. Can either be 'dev' or 'prd'"
+      settings_file:
+        type: string
+        required: true
+        description: "The filename of the appsettings file to use"
 
 jobs:
   build-all:
@@ -14,7 +18,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       publish_artifacts: true
-      environment: ${{ inputs.environment }}
+      settings_file: ${{ inputs.settings_file }}
     secrets: inherit
 
   deploy:

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,0 +1,12 @@
+﻿name: Pull Request
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+    with:
+      settings_file: "appsettings.json"

--- a/.github/workflows/shifty-build.yml
+++ b/.github/workflows/shifty-build.yml
@@ -12,7 +12,6 @@ on:
       settings_file:
         description: "The filename of the appsettings file"
         type: string
-        default: "appsettings.json"
 
 jobs:
   build-test:

--- a/.github/workflows/shifty-build.yml
+++ b/.github/workflows/shifty-build.yml
@@ -9,6 +9,10 @@ on:
         description: "Publish workflow artifacts"
         type: boolean
         default: false
+      environment:
+        description: "Environment to deploy to"
+        type: string
+        default: "dev"
 
 jobs:
   build-test:
@@ -24,6 +28,8 @@ jobs:
           dotnet-version: 6.x
       - name: Restore dependencies
         run: dotnet restore .
+      - name: Settings override
+        run: mv -f "infrastructure/${{ inputs.environment }}.appsettings.json" Shifty.App/wwwroot/appsettings.json
       - name: Build Shifty App
         run: dotnet build . --no-restore /p:ContinuousIntegrationBuild=true --configuration Release
       - name: Run tests

--- a/.github/workflows/shifty-build.yml
+++ b/.github/workflows/shifty-build.yml
@@ -9,10 +9,10 @@ on:
         description: "Publish workflow artifacts"
         type: boolean
         default: false
-      environment:
-        description: "Environment to deploy to"
+      settings_file:
+        description: "The filename of the appsettings file"
         type: string
-        default: "dev"
+        default: "appsettings.json"
 
 jobs:
   build-test:
@@ -29,7 +29,7 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore .
       - name: Settings override
-        run: mv -f "infrastructure/${{ inputs.environment }}.appsettings.json" Shifty.App/wwwroot/appsettings.json
+        run: mv -f "infrastructure/${{ inputs.settings_file }}" Shifty.App/wwwroot/appsettings.json
       - name: Build Shifty App
         run: dotnet build . --no-restore /p:ContinuousIntegrationBuild=true --configuration Release
       - name: Run tests

--- a/Shifty.App/Program.cs
+++ b/Shifty.App/Program.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Blazored.LocalStorage;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Services;
 using Shifty.Api.Generated.AnalogCoreV1;
@@ -19,13 +20,12 @@ namespace Shifty.App
         {
             var builder = WebAssemblyHostBuilder.CreateDefault(args);
             builder.RootComponents.Add<App>("#app");
-
-            ConfigureServices(builder.Services);
+            ConfigureServices(builder.Services, builder.Configuration);
 
             await builder.Build().RunAsync();
         }
 
-        public static void ConfigureServices(IServiceCollection services)
+        public static void ConfigureServices(IServiceCollection services, IConfiguration configuration)
         {
             services.AddMudServices(config =>
             {
@@ -38,7 +38,7 @@ namespace Shifty.App
             services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>()
                 .CreateClient("AnalogCoreV1"));
             services.AddHttpClient("AnalogCoreV1",
-                    client => client.BaseAddress = new Uri("https://core.dev.analogio.dk/"))
+                    client => client.BaseAddress = new Uri(configuration["ApiHost"]))
                 .AddHttpMessageHandler<RequestAuthenticationHandler>();
             services.AddScoped(provider => 
                 new AnalogCoreV1(provider.GetRequiredService<IHttpClientFactory>().CreateClient("AnalogCoreV1")));

--- a/Shifty.App/wwwroot/appsettings.json
+++ b/Shifty.App/wwwroot/appsettings.json
@@ -1,0 +1,3 @@
+﻿{
+  "ApiHost": "http://localhost:8080"
+}

--- a/infrastructure/appsettings.json
+++ b/infrastructure/appsettings.json
@@ -1,0 +1,3 @@
+﻿{
+  "ApiHost": "http://localhost:8080"
+}

--- a/infrastructure/dev.appsettings.json
+++ b/infrastructure/dev.appsettings.json
@@ -1,0 +1,3 @@
+{
+  "ApiHost": "https://core.dev.analogio.dk"
+}

--- a/infrastructure/prd.appsettings.json
+++ b/infrastructure/prd.appsettings.json
@@ -1,0 +1,3 @@
+{
+  "ApiHost": "https://core.prd.analogio.dk"
+}

--- a/infrastructure/shifty.bicep
+++ b/infrastructure/shifty.bicep
@@ -17,7 +17,7 @@ resource staticwebapp 'Microsoft.Web/staticSites@2022-03-01' = {
   properties: {
     allowConfigFileUpdates: false
     repositoryUrl: 'https://github.com/AnalogIO/shifty-webapp'
-    branch: 'develop'
+    branch: 'main'
     provider: 'GitHub'
     stagingEnvironmentPolicy: 'Disabled'
     enterpriseGradeCdnStatus: 'Disabled'


### PR DESCRIPTION
This will add support for injecting configuration options from an appsettings.json file. Currently this will be used to load the correct API host url. The GitHub Actions pipeline has been updated to override the settings based on the deployment environment.