### PR TITLE
Fix routing in hosted Static Web App

### DIFF
--- a/Shifty.App/wwwroot/staticwebapp.config.json
+++ b/Shifty.App/wwwroot/staticwebapp.config.json
@@ -1,7 +1,7 @@
 {
   "trailingSlash": "auto",
   "navigationFallback": {
-    "rewrite": "index.html",
+    "rewrite": "/index.html",
     "exclude": ["/images/*.{png,jpg,gif}", "/css/*"]
   },
   "responseOverrides": {

--- a/infrastructure/shifty.bicep
+++ b/infrastructure/shifty.bicep
@@ -15,7 +15,7 @@ resource staticwebapp 'Microsoft.Web/staticSites@2022-03-01' = {
     tier: 'Free'
   }
   properties: {
-    allowConfigFileUpdates: false
+    allowConfigFileUpdates: true
     repositoryUrl: 'https://github.com/AnalogIO/shifty-webapp'
     branch: 'main'
     provider: 'GitHub'

--- a/infrastructure/staticwebapp.config.json
+++ b/infrastructure/staticwebapp.config.json
@@ -10,7 +10,7 @@
       "statusCode": 302
     },
     "404": {
-      "rewrite": "/404.html"
+      "rewrite": "/index.html"
     }
   }
 }

--- a/infrastructure/staticwebapp.config.json
+++ b/infrastructure/staticwebapp.config.json
@@ -1,0 +1,16 @@
+{
+  "trailingSlash": "auto",
+  "navigationFallback": {
+    "rewrite": "index.html",
+    "exclude": ["/images/*.{png,jpg,gif}", "/css/*"]
+  },
+  "responseOverrides": {
+    "401": {
+      "redirect": "/Login",
+      "statusCode": 302
+    },
+    "404": {
+      "rewrite": "/404.html"
+    }
+  }
+}


### PR DESCRIPTION
This addresses an issue in the hosted Azure Static Web App, where navigating directly to a sub-page, or doing a refresh, will result in a 404 error. This happens because Blazor does client-side routing that intercepts the native browser navigation, so without navigating through the actual app, there is no way for the host to know how to resolve the routes.

To fix this, the config will now fallback to "index.html" when pages are missing, which will allow the client-side routing to kick in and navigate correctly.