### PR TITLE
Adding User Manager

### DIFF
--- a/Shifty.Api/Generated/AnalogCoreV2/AnalogCoreV2.cs
+++ b/Shifty.Api/Generated/AnalogCoreV2/AnalogCoreV2.cs
@@ -733,7 +733,7 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         /// <param name="pageLength">The length of a page</param>
         /// <returns>Users, possible with filter applied</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task<SimpleUserResponse> ApiV2AccountSearchAsync(int? pageNum, string filter, int? pageLength)
+        public virtual System.Threading.Tasks.Task<UserSearchResponse> ApiV2AccountSearchAsync(int? pageNum, string filter, int? pageLength)
         {
             return ApiV2AccountSearchAsync(pageNum, filter, pageLength, System.Threading.CancellationToken.None);
         }
@@ -747,7 +747,7 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         /// <param name="pageLength">The length of a page</param>
         /// <returns>Users, possible with filter applied</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<SimpleUserResponse> ApiV2AccountSearchAsync(int? pageNum, string filter, int? pageLength, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task<UserSearchResponse> ApiV2AccountSearchAsync(int? pageNum, string filter, int? pageLength, System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append("api/v2/account/search?");
@@ -807,7 +807,7 @@ namespace Shifty.Api.Generated.AnalogCoreV2
                         else
                         if (status_ == 200)
                         {
-                            var objectResponse_ = await ReadObjectResponseAsync<SimpleUserResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            var objectResponse_ = await ReadObjectResponseAsync<UserSearchResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
@@ -2705,22 +2705,61 @@ namespace Shifty.Api.Generated.AnalogCoreV2
 
     }
 
+    /// <summary>
+    /// Represents a search result
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
+    public partial class UserSearchResponse
+    {
+        /// <summary>
+        /// The users that match the query
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("users", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<SimpleUserResponse> Users { get; set; } = new System.Collections.ObjectModel.Collection<SimpleUserResponse>();
+
+        /// <summary>
+        /// The number of users that match the query
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("totalUsers", Required = Newtonsoft.Json.Required.Always)]
+        public int TotalUsers { get; set; }
+
+    }
+
+    /// <summary>
+    /// Basic User details
+    /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
     public partial class SimpleUserResponse
     {
+        /// <summary>
+        /// User Id
+        /// </summary>
         [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int Id { get; set; }
 
+        /// <summary>
+        /// User's Display Name
+        /// </summary>
         [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Name { get; set; }
 
+        /// <summary>
+        /// User's Email
+        /// </summary>
         [Newtonsoft.Json.JsonProperty("email", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Email { get; set; }
 
+        /// <summary>
+        /// User's User group relationship
+        /// </summary>
         [Newtonsoft.Json.JsonProperty("userGroup", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public UserGroup UserGroup { get; set; }
 
+        /// <summary>
+        /// User's State
+        /// </summary>
         [Newtonsoft.Json.JsonProperty("state", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public UserState State { get; set; }

--- a/Shifty.Api/Generated/AnalogCoreV2/AnalogCoreV2.cs
+++ b/Shifty.Api/Generated/AnalogCoreV2/AnalogCoreV2.cs
@@ -514,6 +514,115 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         }
 
         /// <summary>
+        /// Updates the user group of a user
+        /// </summary>
+        /// <param name="id">id of the user whose userGroup will be updated</param>
+        /// <param name="updateUserGroupRequest">Update User Group information request</param>
+        /// <returns>The update was processed</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task ApiV2AccountUserGroupAsync(int id, UpdateUserGroupRequest updateUserGroupRequest)
+        {
+            return ApiV2AccountUserGroupAsync(id, updateUserGroupRequest, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Updates the user group of a user
+        /// </summary>
+        /// <param name="id">id of the user whose userGroup will be updated</param>
+        /// <param name="updateUserGroupRequest">Update User Group information request</param>
+        /// <returns>The update was processed</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task ApiV2AccountUserGroupAsync(int id, UpdateUserGroupRequest updateUserGroupRequest, System.Threading.CancellationToken cancellationToken)
+        {
+            if (id == null)
+                throw new System.ArgumentNullException("id");
+
+            if (updateUserGroupRequest == null)
+                throw new System.ArgumentNullException("updateUserGroupRequest");
+
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append("api/v2/account/{id}/user-group");
+            urlBuilder_.Replace("{id}", System.Uri.EscapeDataString(ConvertToString(id, System.Globalization.CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(updateUserGroupRequest, _settings.Value);
+                    var content_ = new System.Net.Http.StringContent(json_);
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("PATCH");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 204)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ApiError>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ApiError>(" Invalid credentials ", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ApiError>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ApiError>(" User not found ", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <summary>
         /// Resend account verification email if account is not already verified
         /// </summary>
         /// <param name="request">Email to be verified</param>
@@ -595,6 +704,115 @@ namespace Shifty.Api.Generated.AnalogCoreV2
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<ApiError>("Account already verified", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Searches a user in the database
+        /// </summary>
+        /// <param name="pageNum">The page number</param>
+        /// <param name="filter">A filter to search by Id, Name or Email. When an empty string is given, all users will be returned</param>
+        /// <param name="pageLength">The length of a page</param>
+        /// <returns>Users, possible with filter applied</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<SimpleUserResponse> ApiV2AccountSearchAsync(int? pageNum, string filter, int? pageLength)
+        {
+            return ApiV2AccountSearchAsync(pageNum, filter, pageLength, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Searches a user in the database
+        /// </summary>
+        /// <param name="pageNum">The page number</param>
+        /// <param name="filter">A filter to search by Id, Name or Email. When an empty string is given, all users will be returned</param>
+        /// <param name="pageLength">The length of a page</param>
+        /// <returns>Users, possible with filter applied</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<SimpleUserResponse> ApiV2AccountSearchAsync(int? pageNum, string filter, int? pageLength, System.Threading.CancellationToken cancellationToken)
+        {
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append("api/v2/account/search?");
+            if (pageNum != null)
+            {
+                urlBuilder_.Append(System.Uri.EscapeDataString("pageNum") + "=").Append(System.Uri.EscapeDataString(ConvertToString(pageNum, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+            }
+            if (filter != null)
+            {
+                urlBuilder_.Append(System.Uri.EscapeDataString("filter") + "=").Append(System.Uri.EscapeDataString(ConvertToString(filter, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+            }
+            if (pageLength != null)
+            {
+                urlBuilder_.Append(System.Uri.EscapeDataString("pageLength") + "=").Append(System.Uri.EscapeDataString(ConvertToString(pageLength, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+            }
+            urlBuilder_.Length--;
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 401)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ApiError>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ApiError>(" Invalid credentials ", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<SimpleUserResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
                         }
                         else
                         {
@@ -1329,7 +1547,7 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         }
 
         /// <summary>
-        /// Returns a list of available products based on a account's user group
+        /// Returns a list of available products based on a account's user group.
         /// </summary>
         /// <returns>Successful request</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
@@ -1340,7 +1558,7 @@ namespace Shifty.Api.Generated.AnalogCoreV2
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Returns a list of available products based on a account's user group
+        /// Returns a list of available products based on a account's user group.
         /// </summary>
         /// <returns>Successful request</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
@@ -1387,6 +1605,12 @@ namespace Shifty.Api.Generated.AnalogCoreV2
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("Invalid credentials", status_, responseText_, headers_, null);
                         }
                         else
                         {
@@ -2433,6 +2657,40 @@ namespace Shifty.Api.Generated.AnalogCoreV2
     }
 
     /// <summary>
+    /// Update the UserGroup property of a user
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
+    public partial class UpdateUserGroupRequest
+    {
+        /// <summary>
+        /// The UserGroup of a user
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("userGroup", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public UserGroup UserGroup { get; set; }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
+    public enum UserGroup
+    {
+
+        [System.Runtime.Serialization.EnumMember(Value = @"Customer")]
+        Customer = 0,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"Barista")]
+        Barista = 1,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"Manager")]
+        Manager = 2,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"Board")]
+        Board = 3,
+
+    }
+
+    /// <summary>
     /// Resend Invite email request
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
@@ -2444,6 +2702,43 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         [Newtonsoft.Json.JsonProperty("email", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required]
         public string Email { get; set; }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
+    public partial class SimpleUserResponse
+    {
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int Id { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Name { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("email", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Email { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("userGroup", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public UserGroup UserGroup { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("state", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public UserState State { get; set; }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
+    public enum UserState
+    {
+
+        [System.Runtime.Serialization.EnumMember(Value = @"Active")]
+        Active = 0,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"Deleted")]
+        Deleted = 1,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"PendingActivition")]
+        PendingActivition = 2,
 
     }
 
@@ -2663,24 +2958,6 @@ namespace Shifty.Api.Generated.AnalogCoreV2
 
     }
 
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
-    public enum UserGroup
-    {
-
-        [System.Runtime.Serialization.EnumMember(Value = @"Customer")]
-        Customer = 0,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"Barista")]
-        Barista = 1,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"Manager")]
-        Manager = 2,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"Board")]
-        Board = 3,
-
-    }
-
     /// <summary>
     /// Initiate a new product add request.
     /// </summary>
@@ -2830,7 +3107,7 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         public bool IsPerk { get; set; }
 
         /// <summary>
-        /// Visibility of products for users 
+        /// Visibility of products for users
         /// </summary>
         [Newtonsoft.Json.JsonProperty("visible", Required = Newtonsoft.Json.Required.Always)]
         public bool Visible { get; set; }

--- a/Shifty.App/Components/UserTable.razor
+++ b/Shifty.App/Components/UserTable.razor
@@ -10,8 +10,8 @@
 
 <MudContainer MaxWidth="MaxWidth.Medium" Style="margin-top: 20px;">
     <MudTable 
-        T="UserSearchResponse" 
-        ServerData="@(new Func<TableState, Task<TableData<UserSearchResponse>>>(LoadUsers))" 
+        T="SimpleUserResponse" 
+        ServerData="@(new Func<TableState, Task<TableData<SimpleUserResponse>>>(LoadUsers))" 
             @ref="_table"
             EditTrigger="TableEditTrigger.EditButton"
             ApplyButtonPosition="TableApplyButtonPosition.End"
@@ -36,22 +36,22 @@
             <MudTh>Id</MudTh>
             <MudTh>Name</MudTh>
             <MudTh>Email</MudTh>
-            <MudTh>Role</MudTh>
+            <MudTh>UserGroup</MudTh>
         </HeaderContent>
         <RowTemplate>
             <MudTd DataLabel="Id">@context.Id</MudTd>
             <MudTd DataLabel="Name">@context.Name</MudTd>
             <MudTd DataLabel="Email">@context.Email</MudTd>
-            <MudTd DataLabel="Role">@context.Role</MudTd>
+            <MudTd DataLabel="UserGroup">@context.UserGroup</MudTd>
         </RowTemplate>
         <RowEditingTemplate>
             <MudTd DataLabel="Id">@context.Id</MudTd>
             <MudTd DataLabel="Name">@context.Name</MudTd>
             <MudTd DataLabel="Email">@context.Email</MudTd>
-            <MudTd DataLabel="Role">
-                <MudSelect T="UserRole" Label="UserRole" @bind-Value="context.Role">
-                    @foreach (var role in Enum.GetValues<UserRole>()) {
-                        <MudSelectItem T="UserRole" Value="@role">@role</MudSelectItem>    
+            <MudTd DataLabel="UserGroup">
+                <MudSelect T="UserGroup" Label="UserGroup" @bind-Value="context.UserGroup">
+                    @foreach (var group in Enum.GetValues<UserGroup>()) {
+                        <MudSelectItem T="UserGroup" Value="@group">@group</MudSelectItem>    
                     }
                 </MudSelect>
             </MudTd>
@@ -66,21 +66,21 @@
 
 @code
 {
-    private MudTable<UserSearchResponse> _table;
+    private MudTable<SimpleUserResponse> _table;
     private string searchString = "";
-    UserRole RoleBeforeEdit;
+    UserGroup UserGroupBeforeEdit;
 
-    private async Task<TableData<UserSearchResponse>> LoadUsers(TableState state)
+    private async Task<TableData<SimpleUserResponse>> LoadUsers(TableState state)
     {
         var result = await _userService.SearchUsers(searchString, state.Page, state.PageSize);
 
         return result.Match(
-            Succ: users => {
-                return new TableData<UserSearchResponse>(){ Items = users.ToList(), TotalItems = 15};;
+            Succ: res => {
+                return new TableData<SimpleUserResponse>(){ Items = res.Users.AsEnumerable(), TotalItems = res.TotalUsers};;
             },
             Fail: error => {
                 Snackbar.Add(error.Message, Severity.Error);
-                return new TableData<UserSearchResponse>(){ Items = new List<UserSearchResponse>(), TotalItems = 0};
+                return new TableData<SimpleUserResponse>(){ Items = new List<SimpleUserResponse>(), TotalItems = 0};
             }
         );
     }
@@ -93,9 +93,9 @@
 
     private void UpdateUserGroup(object element)
     {
-        var user = (UserSearchResponse)element;
+        var user = (SimpleUserResponse)element;
 
-        var result = _userService.UpdateUserGroupAsync(user.Id, UserRoleToUserGroup(user.Role));
+        var result = _userService.UpdateUserGroupAsync(user.Id, user.UserGroup);
 
         result.Match(
             Succ: user => {
@@ -112,26 +112,14 @@
 
     private void BackupUser(object element)
     {
-        RoleBeforeEdit = ((UserSearchResponse)element).Role;
+        UserGroupBeforeEdit = ((SimpleUserResponse)element).UserGroup;
         StateHasChanged();
     }
 
     private void ResetUserOnCancel(object user)
     {
-        ((UserSearchResponse)user).Role = RoleBeforeEdit;
+        ((SimpleUserResponse)user).UserGroup = UserGroupBeforeEdit;
         StateHasChanged();
         Snackbar.Add("Canceled editing", Severity.Warning);
-    }
-
-    public static UserGroup UserRoleToUserGroup(UserRole role)
-    {
-        return role switch
-        {
-            UserRole.Board => UserGroup.Board,
-            UserRole.Manager => UserGroup.Manager,
-            UserRole.Barista => UserGroup.Barista,
-            UserRole.Customer => UserGroup.Customer,
-            _ => throw new Exception("Invalid user role")
-        };
     }
 }

--- a/Shifty.App/Components/UserTable.razor
+++ b/Shifty.App/Components/UserTable.razor
@@ -114,12 +114,10 @@
     {
         RoleBeforeEdit = ((UserSearchResponse)element).Role;
         StateHasChanged();
-        Snackbar.Add(RoleBeforeEdit.ToString(), Severity.Info);
     }
 
     private void ResetUserOnCancel(object user)
     {
-        Snackbar.Add(RoleBeforeEdit.ToString(), Severity.Info);
         ((UserSearchResponse)user).Role = RoleBeforeEdit;
         StateHasChanged();
         Snackbar.Add("Canceled editing", Severity.Warning);

--- a/Shifty.App/Components/UserTable.razor
+++ b/Shifty.App/Components/UserTable.razor
@@ -1,0 +1,139 @@
+@namespace Components
+@using System.ComponentModel.DataAnnotations
+@using Shifty.App.Services
+@using Shifty.Api.Generated.AnalogCoreV1
+@using Shifty.Api.Generated.AnalogCoreV2
+@using Shared
+@using LanguageExt.UnsafeValueAccess
+@inject IUserService _userService
+@inject ISnackbar Snackbar
+
+<MudContainer MaxWidth="MaxWidth.Medium" Style="margin-top: 20px;">
+    <MudTable 
+        T="UserSearchResponse" 
+        ServerData="@(new Func<TableState, Task<TableData<UserSearchResponse>>>(LoadUsers))" 
+            @ref="_table"
+            EditTrigger="TableEditTrigger.EditButton"
+            ApplyButtonPosition="TableApplyButtonPosition.End"
+            EditButtonPosition="TableEditButtonPosition.End"
+            CanCancelEdit="true"
+            RowEditCancel="ResetUserOnCancel"
+            RowEditCommit="UpdateUserGroup"
+            RowEditPreview="BackupUser"
+            IsEditRowSwitchingBlocked="true">
+        <ToolBarContent>
+            <MudText Typo="Typo.h6">Users</MudText>
+            <MudSpacer />
+            <MudTextField 
+                T="string"
+                ValueChanged="@(s => OnSearch(s))" 
+                Placeholder="Search" 
+                Adornment="Adornment.Start" 
+                AdornmentIcon="Icons.Material.Filled.Search" 
+                IconSize="Size.Medium" />
+        </ToolBarContent>
+        <HeaderContent>
+            <MudTh>Id</MudTh>
+            <MudTh>Name</MudTh>
+            <MudTh>Email</MudTh>
+            <MudTh>Role</MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Id">@context.Id</MudTd>
+            <MudTd DataLabel="Name">@context.Name</MudTd>
+            <MudTd DataLabel="Email">@context.Email</MudTd>
+            <MudTd DataLabel="Role">@context.Role</MudTd>
+        </RowTemplate>
+        <RowEditingTemplate>
+            <MudTd DataLabel="Id">@context.Id</MudTd>
+            <MudTd DataLabel="Name">@context.Name</MudTd>
+            <MudTd DataLabel="Email">@context.Email</MudTd>
+            <MudTd DataLabel="Role">
+                <MudSelect T="UserRole" Label="UserRole" @bind-Value="context.Role">
+                    @foreach (var role in Enum.GetValues<UserRole>()) {
+                        <MudSelectItem T="UserRole" Value="@role">@role</MudSelectItem>    
+                    }
+                </MudSelect>
+            </MudTd>
+        </RowEditingTemplate>
+        <NoRecordsContent>No matching records found</NoRecordsContent>
+        <PagerContent><MudTablePager /></PagerContent>
+        <EditButtonContent Context="button">
+            <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Edit" OnClick="@button.ButtonAction" Disabled="@button.ButtonDisabled" />
+        </EditButtonContent>
+    </MudTable>
+</MudContainer>
+
+@code
+{
+    private MudTable<UserSearchResponse> _table;
+    private string searchString = "";
+    UserRole RoleBeforeEdit;
+
+    private async Task<TableData<UserSearchResponse>> LoadUsers(TableState state)
+    {
+        var result = await _userService.SearchUsers(searchString, state.Page, state.PageSize);
+
+        return result.Match(
+            Succ: users => {
+                return new TableData<UserSearchResponse>(){ Items = users.ToList(), TotalItems = 15};;
+            },
+            Fail: error => {
+                Snackbar.Add(error.Message, Severity.Error);
+                return new TableData<UserSearchResponse>(){ Items = new List<UserSearchResponse>(), TotalItems = 0};
+            }
+        );
+    }
+
+    private void OnSearch(string search)
+    {
+        searchString = search;
+        _table.ReloadServerData();
+    }
+
+    private void UpdateUserGroup(object element)
+    {
+        var user = (UserSearchResponse)element;
+
+        var result = _userService.UpdateUserGroupAsync(user.Id, UserRoleToUserGroup(user.Role));
+
+        result.Match(
+            Succ: user => {
+                Snackbar.Add("User updated", Severity.Success);
+            },
+            Fail: error => {
+                Snackbar.Add(error.Message, Severity.Error);
+            }
+        );
+
+        StateHasChanged();
+    }
+
+
+    private void BackupUser(object element)
+    {
+        RoleBeforeEdit = ((UserSearchResponse)element).Role;
+        StateHasChanged();
+        Snackbar.Add(RoleBeforeEdit.ToString(), Severity.Info);
+    }
+
+    private void ResetUserOnCancel(object user)
+    {
+        Snackbar.Add(RoleBeforeEdit.ToString(), Severity.Info);
+        ((UserSearchResponse)user).Role = RoleBeforeEdit;
+        StateHasChanged();
+        Snackbar.Add("Canceled editing", Severity.Warning);
+    }
+
+    public static UserGroup UserRoleToUserGroup(UserRole role)
+    {
+        return role switch
+        {
+            UserRole.Board => UserGroup.Board,
+            UserRole.Manager => UserGroup.Manager,
+            UserRole.Barista => UserGroup.Barista,
+            UserRole.Customer => UserGroup.Customer,
+            _ => throw new Exception("Invalid user role")
+        };
+    }
+}

--- a/Shifty.App/Pages/UserManagement.razor
+++ b/Shifty.App/Pages/UserManagement.razor
@@ -1,0 +1,24 @@
+@page "/Users"
+@using Components
+@inject NavigationManager NavManager
+
+@if (_user is not null && _user.IsInRole("Board"))
+{
+    <UserTable /> 
+}
+
+@code {
+    [CascadingParameter] public Task<AuthenticationState> AuthTask { get; set; }
+    private System.Security.Claims.ClaimsPrincipal _user;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthTask;
+        _user = authState.User;
+
+        if (_user is null || !_user.IsInRole("Board"))
+        {
+            NavManager.NavigateTo("/");
+        }
+    }
+}

--- a/Shifty.App/Program.cs
+++ b/Shifty.App/Program.cs
@@ -60,6 +60,7 @@ namespace Shifty.App
             services.AddScoped<IAuthenticationService, AuthenticationService>();
             services.AddScoped<IVoucherService, VoucherService>();
             services.AddScoped<IProductService, ProductService>();
+            services.AddScoped<IUserService, UserService>();
             services.AddScoped<RequestAuthenticationHandler>();
 
             services.AddMudServices(config =>

--- a/Shifty.App/Repositories/AccountRepository.cs
+++ b/Shifty.App/Repositories/AccountRepository.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using LanguageExt;
+using LanguageExt.ClassInstances.Pred;
 using LanguageExt.Common;
 using Shifty.Api.Generated.AnalogCoreV1;
 using Shifty.Api.Generated.AnalogCoreV2;
@@ -30,9 +31,9 @@ namespace Shifty.App.Repositories
             return await TryAsync(_v1client.ApiV1AccountLoginAsync(loginDto: dto)).ToEither();
         }
 
-        public async Task<Try<ICollection<UserSearchResponse>>> SearchUserAsync(string query, int page, int pageSize)
+        public async Task<Try<UserSearchResponse>> SearchUserAsync(string query, int page, int pageSize)
         {
-            return await TryAsync(_v2client.ApiV2AccountSearchAsync(query, page, pageSize));
+            return await TryAsync(_v2client.ApiV2AccountSearchAsync(filter: query, pageNum: page, pageLength: pageSize));
         }
 
         public async Task<Try<Task>> UpdateUserGroupAsync(int userId, UserGroup group)

--- a/Shifty.App/Repositories/AccountRepository.cs
+++ b/Shifty.App/Repositories/AccountRepository.cs
@@ -1,21 +1,25 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using LanguageExt;
 using LanguageExt.Common;
 using Shifty.Api.Generated.AnalogCoreV1;
+using Shifty.Api.Generated.AnalogCoreV2;
 using static LanguageExt.Prelude;
 
 namespace Shifty.App.Repositories
 {
     public class AccountRepository : IAccountRepository
     {
-        private readonly AnalogCoreV1 _client;
+        private readonly AnalogCoreV1 _v1client;
+        private readonly AnalogCoreV2 _v2client;
 
-        public AccountRepository(AnalogCoreV1 client)
+        public AccountRepository(AnalogCoreV1 v1client, AnalogCoreV2 v2client)
         {
-            _client = client;
+            _v1client = v1client;
+            _v2client = v2client;
         }
-        
-        public async Task<Either<Error, TokenDto>> LoginAsync(string username, string password)
+
+    public async Task<Either<Error, TokenDto>> LoginAsync(string username, string password)
         {
             var dto = new LoginDto()
             {
@@ -23,7 +27,17 @@ namespace Shifty.App.Repositories
                 Password = password,
                 Version = "2.1.0"
             };
-            return await TryAsync(_client.ApiV1AccountLoginAsync(loginDto: dto)).ToEither();
+            return await TryAsync(_v1client.ApiV1AccountLoginAsync(loginDto: dto)).ToEither();
+        }
+
+        public async Task<Try<ICollection<UserSearchResponse>>> SearchUserAsync(string query, int page, int pageSize)
+        {
+            return await TryAsync(_v2client.ApiV2AccountSearchAsync(query, page, pageSize));
+        }
+
+        public async Task<Try<Task>> UpdateUserGroupAsync(int userId, UserGroup group)
+        {
+            return await TryAsync(_v2client.ApiV2AccountUserGroupAsync(userId, new(){UserGroup = group}));
         }
     }
 }

--- a/Shifty.App/Repositories/IAccountRepository.cs
+++ b/Shifty.App/Repositories/IAccountRepository.cs
@@ -1,12 +1,16 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using LanguageExt;
 using LanguageExt.Common;
 using Shifty.Api.Generated.AnalogCoreV1;
+using Shifty.Api.Generated.AnalogCoreV2;
 
 namespace Shifty.App.Repositories
 {
     public interface IAccountRepository
     {
         public Task<Either<Error, TokenDto>> LoginAsync(string username, string password);
+        public Task<Try<ICollection<UserSearchResponse>>> SearchUserAsync(string query, int page, int pageSize);
+        public Task<Try<Task>> UpdateUserGroupAsync(int userId, UserGroup group);
     }
 }

--- a/Shifty.App/Repositories/IAccountRepository.cs
+++ b/Shifty.App/Repositories/IAccountRepository.cs
@@ -10,7 +10,7 @@ namespace Shifty.App.Repositories
     public interface IAccountRepository
     {
         public Task<Either<Error, TokenDto>> LoginAsync(string username, string password);
-        public Task<Try<ICollection<UserSearchResponse>>> SearchUserAsync(string query, int page, int pageSize);
+        public Task<Try<UserSearchResponse>> SearchUserAsync(string query, int page, int pageSize);
         public Task<Try<Task>> UpdateUserGroupAsync(int userId, UserGroup group);
     }
 }

--- a/Shifty.App/Services/IUserService.cs
+++ b/Shifty.App/Services/IUserService.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LanguageExt;
+using LanguageExt.Common;
+using Shifty.Api.Generated.AnalogCoreV2;
+
+namespace Shifty.App.Services
+{
+    public interface IUserService
+    {
+        Task<Try<ICollection<UserSearchResponse>>> SearchUsers(string query, int pageNumber = 0, int pageSize = 10);
+        Task<Try<Task>> UpdateUserGroupAsync(int userId, UserGroup group);
+    }
+}

--- a/Shifty.App/Services/IUserService.cs
+++ b/Shifty.App/Services/IUserService.cs
@@ -8,7 +8,7 @@ namespace Shifty.App.Services
 {
     public interface IUserService
     {
-        Task<Try<ICollection<UserSearchResponse>>> SearchUsers(string query, int pageNumber = 0, int pageSize = 10);
+        Task<Try<UserSearchResponse>> SearchUsers(string query, int pageNumber = 0, int pageSize = 10);
         Task<Try<Task>> UpdateUserGroupAsync(int userId, UserGroup group);
     }
 }

--- a/Shifty.App/Services/UserService.cs
+++ b/Shifty.App/Services/UserService.cs
@@ -17,7 +17,7 @@ namespace Shifty.App.Services
             _accountRepository = accountRepository;
         }
 
-        public Task<Try<ICollection<UserSearchResponse>>> SearchUsers(string query, int pageNumber = 0, int pageSize = 10)
+        public Task<Try<UserSearchResponse>> SearchUsers(string query, int pageNumber = 0, int pageSize = 10)
         {
             return _accountRepository.SearchUserAsync(query, pageNumber, pageSize);
         }

--- a/Shifty.App/Services/UserService.cs
+++ b/Shifty.App/Services/UserService.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Blazored.LocalStorage;
+using LanguageExt;
+using LanguageExt.Common;
+using Shifty.Api.Generated.AnalogCoreV2;
+using Shifty.App.Repositories;
+
+namespace Shifty.App.Services
+{
+    public class UserService : IUserService
+    {
+        private readonly IAccountRepository _accountRepository;
+        
+        public UserService(IAccountRepository accountRepository)
+        {
+            _accountRepository = accountRepository;
+        }
+
+        public Task<Try<ICollection<UserSearchResponse>>> SearchUsers(string query, int pageNumber = 0, int pageSize = 10)
+        {
+            return _accountRepository.SearchUserAsync(query, pageNumber, pageSize);
+        }
+
+        public Task<Try<Task>> UpdateUserGroupAsync(int userId, UserGroup group)
+        {
+            return _accountRepository.UpdateUserGroupAsync(userId, group);  
+        }
+    }
+}

--- a/Shifty.App/Shared/NavMenu.razor
+++ b/Shifty.App/Shared/NavMenu.razor
@@ -4,6 +4,7 @@
     {     
         <MudNavLink Href="Voucher" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Sell">Issue vouchers</MudNavLink>
         <MudNavLink Href="Products" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Outlined.Inventory">Product Management</MudNavLink>
+        <MudNavLink Href="Users" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.ManageAccounts">Manage users</MudNavLink>
     }
 </MudNavMenu>
 

--- a/Shifty.GenerateApi/OpenApiSpecs/AnalogCoreV2.json
+++ b/Shifty.GenerateApi/OpenApiSpecs/AnalogCoreV2.json
@@ -383,7 +383,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SimpleUserResponse"
+                  "$ref": "#/components/schemas/UserSearchResponse"
                 }
               }
             }
@@ -1451,25 +1451,81 @@
           }
         }
       },
+      "UserSearchResponse": {
+        "type": "object",
+        "description": "Represents a search result",
+        "example": {
+          "users": [
+            {
+              "id": 12232,
+              "name": "John Doe",
+              "email": "johndoe@itu.dk",
+              "userGroup": "Barista",
+              "state": "Active"
+            }
+          ],
+          "totalUsers": 1
+        },
+        "additionalProperties": false,
+        "required": [
+          "users",
+          "totalUsers"
+        ],
+        "properties": {
+          "users": {
+            "type": "array",
+            "description": "The users that match the query",
+            "example": "[\n   {\n     \"id\": 12232,\n     \"name\": \"John Doe\",\n     \"email\": \"johndoe@itu.dk\",\n     \"userGroup\": \"Barista\",\n     \"state\": \"Active\"\n   }\n ],",
+            "items": {
+              "$ref": "#/components/schemas/SimpleUserResponse"
+            }
+          },
+          "totalUsers": {
+            "type": "integer",
+            "description": "The number of users that match the query",
+            "format": "int32",
+            "example": 1
+          }
+        }
+      },
       "SimpleUserResponse": {
         "type": "object",
+        "description": "Basic User details",
         "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int32"
+            "description": "User Id",
+            "format": "int32",
+            "example": 1
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "User's Display Name",
+            "example": "Name"
           },
           "email": {
-            "type": "string"
+            "type": "string",
+            "description": "User's Email",
+            "example": "john@doe.test"
           },
           "userGroup": {
-            "$ref": "#/components/schemas/UserGroup"
+            "description": "User's User group relationship",
+            "example": "Barista",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/UserGroup"
+              }
+            ]
           },
           "state": {
-            "$ref": "#/components/schemas/UserState"
+            "description": "User's State",
+            "example": "Active",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/UserState"
+              }
+            ]
           }
         }
       },

--- a/Shifty.GenerateApi/OpenApiSpecs/AnalogCoreV2.json
+++ b/Shifty.GenerateApi/OpenApiSpecs/AnalogCoreV2.json
@@ -208,6 +208,74 @@
         }
       }
     },
+    "/api/v2/account/{id}/user-group": {
+      "patch": {
+        "tags": [
+          "Account"
+        ],
+        "summary": "Updates the user group of a user",
+        "operationId": "Account_UpdateAccountUserGroup",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "id of the user whose userGroup will be updated ",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "updateUserGroupRequest",
+          "description": "Update User Group information request  ",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateUserGroupRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "204": {
+            "description": " The update was processed "
+          },
+          "401": {
+            "description": " Invalid credentials ",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": " User not found ",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "apikey": []
+          }
+        ]
+      }
+    },
     "/api/v2/account/resend-verification-email": {
       "post": {
         "tags": [
@@ -253,6 +321,82 @@
             }
           }
         }
+      }
+    },
+    "/api/v2/account/search": {
+      "get": {
+        "tags": [
+          "Account"
+        ],
+        "summary": "Searches a user in the database",
+        "operationId": "Account_SearchUsers",
+        "parameters": [
+          {
+            "name": "pageNum",
+            "in": "query",
+            "description": "The page number",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "maximum": 2147483647.0,
+              "minimum": 0.0
+            },
+            "x-position": 1
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "A filter to search by Id, Name or Email. When an empty string is given, all users will be returned",
+            "schema": {
+              "type": "string",
+              "default": ""
+            },
+            "x-position": 2
+          },
+          {
+            "name": "pageLength",
+            "in": "query",
+            "description": "The length of a page",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 30,
+              "maximum": 100.0,
+              "minimum": 1.0
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": " Invalid credentials ",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Users, possible with filter applied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimpleUserResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "apikey": []
+          }
+        ]
       }
     },
     "/api/v2/appconfig": {
@@ -583,7 +727,7 @@
         "tags": [
           "Products"
         ],
-        "summary": "Returns a list of available products based on a account's user group",
+        "summary": "Returns a list of available products based on a account's user group.",
         "operationId": "Products_GetProducts",
         "responses": {
           "200": {
@@ -598,8 +742,19 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Invalid credentials"
           }
-        }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "apikey": []
+          }
+        ]
       }
     },
     "/api/v2/products/all": {
@@ -970,7 +1125,7 @@
           "name": "John Doe",
           "email": "john@doe.com",
           "password": "[no example provided]",
-          "programme": 1
+          "programmeId": 1
         },
         "additionalProperties": false,
         "required": [
@@ -1238,6 +1393,44 @@
           }
         }
       },
+      "UpdateUserGroupRequest": {
+        "type": "object",
+        "description": "Update the UserGroup property of a user",
+        "example": {
+          "UserGroup": "Barista"
+        },
+        "additionalProperties": false,
+        "required": [
+          "userGroup"
+        ],
+        "properties": {
+          "userGroup": {
+            "description": "The UserGroup of a user",
+            "example": "UserGroup.Barista ",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/UserGroup"
+              }
+            ]
+          }
+        }
+      },
+      "UserGroup": {
+        "type": "string",
+        "description": "",
+        "x-enumNames": [
+          "Customer",
+          "Barista",
+          "Manager",
+          "Board"
+        ],
+        "enum": [
+          "Customer",
+          "Barista",
+          "Manager",
+          "Board"
+        ]
+      },
       "ResendAccountVerificationEmailRequest": {
         "type": "object",
         "description": "Resend Invite email request",
@@ -1257,6 +1450,42 @@
             "example": "john@doe.com"
           }
         }
+      },
+      "SimpleUserResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "userGroup": {
+            "$ref": "#/components/schemas/UserGroup"
+          },
+          "state": {
+            "$ref": "#/components/schemas/UserState"
+          }
+        }
+      },
+      "UserState": {
+        "type": "string",
+        "description": "",
+        "x-enumNames": [
+          "Active",
+          "Deleted",
+          "PendingActivition"
+        ],
+        "enum": [
+          "Active",
+          "Deleted",
+          "PendingActivition"
+        ]
       },
       "AppConfig": {
         "type": "object",
@@ -1481,22 +1710,6 @@
           }
         }
       },
-      "UserGroup": {
-        "type": "string",
-        "description": "",
-        "x-enumNames": [
-          "Customer",
-          "Barista",
-          "Manager",
-          "Board"
-        ],
-        "enum": [
-          "Customer",
-          "Barista",
-          "Manager",
-          "Board"
-        ]
-      },
       "AddProductRequest": {
         "type": "object",
         "description": "Initiate a new product add request.",
@@ -1649,6 +1862,7 @@
           "name": "Coffee clip card",
           "description": "Coffee clip card of 10 clips",
           "isPerk": true,
+          "visible": true,
           "AllowedUserGroups": [
             "Manager",
             "Board"
@@ -1703,7 +1917,7 @@
           },
           "visible": {
             "type": "boolean",
-            "description": "Visibility of products for users ",
+            "description": "Visibility of products for users",
             "example": true
           },
           "allowedUserGroups": {


### PR DESCRIPTION
Adds a way to manage the group that a user belongs to.

Fixes #6 

User interface looks like this:
![image](https://github.com/AnalogIO/shifty-webapp/assets/95026056/4cce6df9-a79c-4a5a-9df1-dd76f1c0c34b)

We can only edit one element at a time (remaining edit icons are disabled until you commit / cancel changes). 
Search field uses backend search engine meaning we only pass a query
Only UserGroup field is editable. MudTable allows easily defining which elements are editable if we want to extend this in the future.