### PR TITLE
Menuitems on products

### DIFF
--- a/Shifty.Api/Generated/AnalogCoreV2/AnalogCoreV2.cs
+++ b/Shifty.Api/Generated/AnalogCoreV2/AnalogCoreV2.cs
@@ -2803,6 +2803,101 @@ namespace Shifty.Api.Generated.AnalogCoreV2
             }
         }
 
+        /// <summary>
+        /// Update user groups in bulk
+        /// </summary>
+        /// <param name="request">The request containing the new user groups</param>
+        /// <returns>The user groups were updated</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task ApiV2WebhooksAccountsUserGroupAsync(WebhookUpdateUserGroupRequest request)
+        {
+            return ApiV2WebhooksAccountsUserGroupAsync(request, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Update user groups in bulk
+        /// </summary>
+        /// <param name="request">The request containing the new user groups</param>
+        /// <returns>The user groups were updated</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task ApiV2WebhooksAccountsUserGroupAsync(WebhookUpdateUserGroupRequest request, System.Threading.CancellationToken cancellationToken)
+        {
+            if (request == null)
+                throw new System.ArgumentNullException("request");
+
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append("api/v2/webhooks/accounts/user-group");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new System.Net.Http.StringContent(json_);
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("PUT");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 204)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("Invalid credentials", status_, responseText_, headers_, null);
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("Bad request. See explanation", status_, responseText_, headers_, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
         protected struct ObjectResponseResult<T>
         {
             public ObjectResponseResult(T responseObject, string responseText)
@@ -3199,17 +3294,17 @@ namespace Shifty.Api.Generated.AnalogCoreV2
     public partial class UserSearchResponse
     {
         /// <summary>
+        /// The number of users that match the query
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("totalUsers", Required = Newtonsoft.Json.Required.Always)]
+        public int TotalUsers { get; set; }
+
+        /// <summary>
         /// The users that match the query
         /// </summary>
         [Newtonsoft.Json.JsonProperty("users", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required]
         public System.Collections.Generic.ICollection<SimpleUserResponse> Users { get; set; } = new System.Collections.ObjectModel.Collection<SimpleUserResponse>();
-
-        /// <summary>
-        /// The number of users that match the query
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("totalUsers", Required = Newtonsoft.Json.Required.Always)]
-        public int TotalUsers { get; set; }
 
     }
 
@@ -3798,6 +3893,9 @@ namespace Shifty.Api.Generated.AnalogCoreV2
 
     }
 
+    [Newtonsoft.Json.JsonConverter(typeof(JsonInheritanceConverter), "discriminator")]
+    [JsonInheritanceAttribute("MobilePayPaymentDetails", typeof(MobilePayPaymentDetails))]
+    [JsonInheritanceAttribute("FreePurchasePaymentDetails", typeof(FreePurchasePaymentDetails))]
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
     public partial class PaymentDetails
     {
@@ -3852,12 +3950,6 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         [Newtonsoft.Json.JsonProperty("paymentId", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required]
         public string PaymentId { get; set; }
-
-        /// <summary>
-        /// MobilePay state
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("state", Required = Newtonsoft.Json.Required.AllowNull)]
-        public string State { get; set; }
 
     }
 
@@ -3970,7 +4062,7 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         /// <summary>
         /// Used date time for ticket in Utc format
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("dateUsed", Required = Newtonsoft.Json.Required.AllowNull)]
+        [Newtonsoft.Json.JsonProperty("dateUsed", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.DateTimeOffset? DateUsed { get; set; }
 
         /// <summary>
@@ -4130,6 +4222,180 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         [System.ComponentModel.DataAnnotations.Required]
         public string Requester { get; set; }
 
+    }
+
+    /// <summary>
+    /// Represents a request to update user groups in bulk
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
+    public partial class WebhookUpdateUserGroupRequest
+    {
+        /// <summary>
+        /// List of accounts and their new user groups
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("privilegedUsers", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<AccountUserGroup> PrivilegedUsers { get; set; } = new System.Collections.ObjectModel.Collection<AccountUserGroup>();
+
+    }
+
+    /// <summary>
+    /// Represents an account user group update
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
+    public partial class AccountUserGroup
+    {
+        /// <summary>
+        /// The account id
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("accountId", Required = Newtonsoft.Json.Required.Always)]
+        public int AccountId { get; set; }
+
+        /// <summary>
+        /// The user group
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("userGroup", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public UserGroup UserGroup { get; set; }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple = true)]
+    internal class JsonInheritanceAttribute : System.Attribute
+    {
+        public JsonInheritanceAttribute(string key, System.Type type)
+        {
+            Key = key;
+            Type = type;
+        }
+
+        public string Key { get; }
+
+        public System.Type Type { get; }
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
+    public class JsonInheritanceConverter : Newtonsoft.Json.JsonConverter
+    {
+        internal static readonly string DefaultDiscriminatorName = "discriminator";
+
+        private readonly string _discriminatorName;
+
+        [System.ThreadStatic]
+        private static bool _isReading;
+
+        [System.ThreadStatic]
+        private static bool _isWriting;
+
+        public JsonInheritanceConverter()
+        {
+            _discriminatorName = DefaultDiscriminatorName;
+        }
+
+        public JsonInheritanceConverter(string discriminatorName)
+        {
+            _discriminatorName = discriminatorName;
+        }
+
+        public string DiscriminatorName { get { return _discriminatorName; } }
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer)
+        {
+            try
+            {
+                _isWriting = true;
+
+                var jObject = Newtonsoft.Json.Linq.JObject.FromObject(value, serializer);
+                jObject.AddFirst(new Newtonsoft.Json.Linq.JProperty(_discriminatorName, GetSubtypeDiscriminator(value.GetType())));
+                writer.WriteToken(jObject.CreateReader());
+            }
+            finally
+            {
+                _isWriting = false;
+            }
+        }
+
+        public override bool CanWrite
+        {
+            get
+            {
+                if (_isWriting)
+                {
+                    _isWriting = false;
+                    return false;
+                }
+                return true;
+            }
+        }
+
+        public override bool CanRead
+        {
+            get
+            {
+                if (_isReading)
+                {
+                    _isReading = false;
+                    return false;
+                }
+                return true;
+            }
+        }
+
+        public override bool CanConvert(System.Type objectType)
+        {
+            return true;
+        }
+
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
+        {
+            var jObject = serializer.Deserialize<Newtonsoft.Json.Linq.JObject>(reader);
+            if (jObject == null)
+                return null;
+
+            var discriminatorValue = jObject.GetValue(_discriminatorName);
+            var discriminator = discriminatorValue != null ? Newtonsoft.Json.Linq.Extensions.Value<string>(discriminatorValue) : null;
+            var subtype = GetObjectSubtype(objectType, discriminator);
+
+            var objectContract = serializer.ContractResolver.ResolveContract(subtype) as Newtonsoft.Json.Serialization.JsonObjectContract;
+            if (objectContract == null || System.Linq.Enumerable.All(objectContract.Properties, p => p.PropertyName != _discriminatorName))
+            {
+                jObject.Remove(_discriminatorName);
+            }
+
+            try
+            {
+                _isReading = true;
+                return serializer.Deserialize(jObject.CreateReader(), subtype);
+            }
+            finally
+            {
+                _isReading = false;
+            }
+        }
+
+        private System.Type GetObjectSubtype(System.Type objectType, string discriminator)
+        {
+            foreach (var attribute in System.Reflection.CustomAttributeExtensions.GetCustomAttributes<JsonInheritanceAttribute>(System.Reflection.IntrospectionExtensions.GetTypeInfo(objectType), true))
+            {
+                if (attribute.Key == discriminator)
+                    return attribute.Type;
+            }
+
+            return objectType;
+        }
+
+        private string GetSubtypeDiscriminator(System.Type objectType)
+        {
+            foreach (var attribute in System.Reflection.CustomAttributeExtensions.GetCustomAttributes<JsonInheritanceAttribute>(System.Reflection.IntrospectionExtensions.GetTypeInfo(objectType), true))
+            {
+                if (attribute.Type == objectType)
+                    return attribute.Key;
+            }
+
+            return objectType.Name;
+        }
     }
 
 

--- a/Shifty.Api/Generated/AnalogCoreV2/AnalogCoreV2.cs
+++ b/Shifty.Api/Generated/AnalogCoreV2/AnalogCoreV2.cs
@@ -1442,6 +1442,7 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         /// <summary>
         /// Updates a menu item
         /// </summary>
+        /// <param name="id">Menu item id to update</param>
         /// <param name="menuItem">Menu item to update</param>
         /// <returns>Menu item successfully updated</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
@@ -1454,6 +1455,7 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         /// <summary>
         /// Updates a menu item
         /// </summary>
+        /// <param name="id">Menu item id to update</param>
         /// <param name="menuItem">Menu item to update</param>
         /// <returns>Menu item successfully updated</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
@@ -2956,7 +2958,7 @@ namespace Shifty.Api.Generated.AnalogCoreV2
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
     public partial class ApiError
     {
-        [Newtonsoft.Json.JsonProperty("message", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("message", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Message { get; set; }
 
     }
@@ -3386,6 +3388,12 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         [System.ComponentModel.DataAnnotations.Required]
         public string Name { get; set; }
 
+        /// <summary>
+        /// Whether or not this menu item is active
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("active", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool Active { get; set; }
+
     }
 
     /// <summary>
@@ -3415,6 +3423,12 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required]
         public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the updated active status of the product.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("active", Required = Newtonsoft.Json.Required.Always)]
+        public bool Active { get; set; }
 
     }
 
@@ -3784,9 +3798,6 @@ namespace Shifty.Api.Generated.AnalogCoreV2
 
     }
 
-    [Newtonsoft.Json.JsonConverter(typeof(JsonInheritanceConverter), "discriminator")]
-    [JsonInheritanceAttribute("MobilePayPaymentDetails", typeof(MobilePayPaymentDetails))]
-    [JsonInheritanceAttribute("FreePurchasePaymentDetails", typeof(FreePurchasePaymentDetails))]
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
     public partial class PaymentDetails
     {
@@ -3825,7 +3836,6 @@ namespace Shifty.Api.Generated.AnalogCoreV2
     /// <summary>
     /// MobilePay Payment details
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(JsonInheritanceConverter), "discriminator")]
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
     public partial class MobilePayPaymentDetails : PaymentDetails
     {
@@ -3854,7 +3864,6 @@ namespace Shifty.Api.Generated.AnalogCoreV2
     /// <summary>
     /// Payment details for a free purchase
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(JsonInheritanceConverter), "discriminator")]
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
     public partial class FreePurchasePaymentDetails : PaymentDetails
     {
@@ -4121,143 +4130,6 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         [System.ComponentModel.DataAnnotations.Required]
         public string Requester { get; set; }
 
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
-    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple = true)]
-    internal class JsonInheritanceAttribute : System.Attribute
-    {
-        public JsonInheritanceAttribute(string key, System.Type type)
-        {
-            Key = key;
-            Type = type;
-        }
-
-        public string Key { get; }
-
-        public System.Type Type { get; }
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
-    public class JsonInheritanceConverter : Newtonsoft.Json.JsonConverter
-    {
-        internal static readonly string DefaultDiscriminatorName = "discriminator";
-
-        private readonly string _discriminatorName;
-
-        [System.ThreadStatic]
-        private static bool _isReading;
-
-        [System.ThreadStatic]
-        private static bool _isWriting;
-
-        public JsonInheritanceConverter()
-        {
-            _discriminatorName = DefaultDiscriminatorName;
-        }
-
-        public JsonInheritanceConverter(string discriminatorName)
-        {
-            _discriminatorName = discriminatorName;
-        }
-
-        public string DiscriminatorName { get { return _discriminatorName; } }
-
-        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer)
-        {
-            try
-            {
-                _isWriting = true;
-
-                var jObject = Newtonsoft.Json.Linq.JObject.FromObject(value, serializer);
-                jObject.AddFirst(new Newtonsoft.Json.Linq.JProperty(_discriminatorName, GetSubtypeDiscriminator(value.GetType())));
-                writer.WriteToken(jObject.CreateReader());
-            }
-            finally
-            {
-                _isWriting = false;
-            }
-        }
-
-        public override bool CanWrite
-        {
-            get
-            {
-                if (_isWriting)
-                {
-                    _isWriting = false;
-                    return false;
-                }
-                return true;
-            }
-        }
-
-        public override bool CanRead
-        {
-            get
-            {
-                if (_isReading)
-                {
-                    _isReading = false;
-                    return false;
-                }
-                return true;
-            }
-        }
-
-        public override bool CanConvert(System.Type objectType)
-        {
-            return true;
-        }
-
-        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
-        {
-            var jObject = serializer.Deserialize<Newtonsoft.Json.Linq.JObject>(reader);
-            if (jObject == null)
-                return null;
-
-            var discriminatorValue = jObject.GetValue(_discriminatorName);
-            var discriminator = discriminatorValue != null ? Newtonsoft.Json.Linq.Extensions.Value<string>(discriminatorValue) : null;
-            var subtype = GetObjectSubtype(objectType, discriminator);
-
-            var objectContract = serializer.ContractResolver.ResolveContract(subtype) as Newtonsoft.Json.Serialization.JsonObjectContract;
-            if (objectContract == null || System.Linq.Enumerable.All(objectContract.Properties, p => p.PropertyName != _discriminatorName))
-            {
-                jObject.Remove(_discriminatorName);
-            }
-
-            try
-            {
-                _isReading = true;
-                return serializer.Deserialize(jObject.CreateReader(), subtype);
-            }
-            finally
-            {
-                _isReading = false;
-            }
-        }
-
-        private System.Type GetObjectSubtype(System.Type objectType, string discriminator)
-        {
-            foreach (var attribute in System.Reflection.CustomAttributeExtensions.GetCustomAttributes<JsonInheritanceAttribute>(System.Reflection.IntrospectionExtensions.GetTypeInfo(objectType), true))
-            {
-                if (attribute.Key == discriminator)
-                    return attribute.Type;
-            }
-
-            return objectType;
-        }
-
-        private string GetSubtypeDiscriminator(System.Type objectType)
-        {
-            foreach (var attribute in System.Reflection.CustomAttributeExtensions.GetCustomAttributes<JsonInheritanceAttribute>(System.Reflection.IntrospectionExtensions.GetTypeInfo(objectType), true))
-            {
-                if (attribute.Type == objectType)
-                    return attribute.Key;
-            }
-
-            return objectType.Name;
-        }
     }
 
 

--- a/Shifty.Api/Generated/AnalogCoreV2/AnalogCoreV2.cs
+++ b/Shifty.Api/Generated/AnalogCoreV2/AnalogCoreV2.cs
@@ -1271,6 +1271,268 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         }
 
         /// <summary>
+        /// Returns a list of all menu items
+        /// </summary>
+        /// <returns>Successful request</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.ICollection<MenuItemResponse>> ApiV2MenuitemsGetAsync()
+        {
+            return ApiV2MenuitemsGetAsync(System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Returns a list of all menu items
+        /// </summary>
+        /// <returns>Successful request</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<MenuItemResponse>> ApiV2MenuitemsGetAsync(System.Threading.CancellationToken cancellationToken)
+        {
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append("api/v2/menuitems");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<System.Collections.Generic.ICollection<MenuItemResponse>>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Adds a menu item
+        /// </summary>
+        /// <param name="menuItem">Menu item to add</param>
+        /// <returns>Menu item successfully added</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<MenuItemResponse> ApiV2MenuitemsPostAsync(AddMenuItemRequest menuItem)
+        {
+            return ApiV2MenuitemsPostAsync(menuItem, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Adds a menu item
+        /// </summary>
+        /// <param name="menuItem">Menu item to add</param>
+        /// <returns>Menu item successfully added</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<MenuItemResponse> ApiV2MenuitemsPostAsync(AddMenuItemRequest menuItem, System.Threading.CancellationToken cancellationToken)
+        {
+            if (menuItem == null)
+                throw new System.ArgumentNullException("menuItem");
+
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append("api/v2/menuitems");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(menuItem, _settings.Value);
+                    var content_ = new System.Net.Http.StringContent(json_);
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("POST");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 201)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<MenuItemResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Updates a menu item
+        /// </summary>
+        /// <param name="menuItem">Menu item to update</param>
+        /// <returns>Menu item successfully updated</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<MenuItemResponse> ApiV2MenuitemsPutAsync(int id, UpdateMenuItemRequest menuItem)
+        {
+            return ApiV2MenuitemsPutAsync(id, menuItem, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Updates a menu item
+        /// </summary>
+        /// <param name="menuItem">Menu item to update</param>
+        /// <returns>Menu item successfully updated</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<MenuItemResponse> ApiV2MenuitemsPutAsync(int id, UpdateMenuItemRequest menuItem, System.Threading.CancellationToken cancellationToken)
+        {
+            if (id == null)
+                throw new System.ArgumentNullException("id");
+
+            if (menuItem == null)
+                throw new System.ArgumentNullException("menuItem");
+
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append("api/v2/menuitems/{id}");
+            urlBuilder_.Replace("{id}", System.Uri.EscapeDataString(ConvertToString(id, System.Globalization.CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(menuItem, _settings.Value);
+                    var content_ = new System.Net.Http.StringContent(json_);
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("PUT");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<MenuItemResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <summary>
         /// Webhook to be invoked by MobilePay backend
         /// </summary>
         /// <param name="mpSignatureHeader">Webhook signature</param>
@@ -1611,6 +1873,108 @@ namespace Shifty.Api.Generated.AnalogCoreV2
                         {
                             string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new ApiException("Invalid credentials", status_, responseText_, headers_, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Returns a product with the specified id
+        /// </summary>
+        /// <param name="id">The id of the product to be returned</param>
+        /// <returns>Successful request</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<ProductResponse> ApiV2ProductsGetAsync(int id)
+        {
+            return ApiV2ProductsGetAsync(id, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Returns a product with the specified id
+        /// </summary>
+        /// <param name="id">The id of the product to be returned</param>
+        /// <returns>Successful request</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<ProductResponse> ApiV2ProductsGetAsync(int id, System.Threading.CancellationToken cancellationToken)
+        {
+            if (id == null)
+                throw new System.ArgumentNullException("id");
+
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append("api/v2/products/{id}");
+            urlBuilder_.Replace("{id}", System.Uri.EscapeDataString(ConvertToString(id, System.Globalization.CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProductResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("Invalid credentials", status_, responseText_, headers_, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ApiError>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ApiError>("The product with the specified id could not be found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         {
@@ -2073,6 +2437,121 @@ namespace Shifty.Api.Generated.AnalogCoreV2
                         {
                             string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new ApiException("Invalid credentials", status_, responseText_, headers_, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Uses a ticket (for the given product) on the given menu item
+        /// </summary>
+        /// <param name="request">The product id and menu item id to use a ticket for</param>
+        /// <returns>Successful request</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<UsedTicketResponse> ApiV2TicketsUseAsync(UseTicketRequest request)
+        {
+            return ApiV2TicketsUseAsync(request, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Uses a ticket (for the given product) on the given menu item
+        /// </summary>
+        /// <param name="request">The product id and menu item id to use a ticket for</param>
+        /// <returns>Successful request</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<UsedTicketResponse> ApiV2TicketsUseAsync(UseTicketRequest request, System.Threading.CancellationToken cancellationToken)
+        {
+            if (request == null)
+                throw new System.ArgumentNullException("request");
+
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append("api/v2/tickets/use");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new System.Net.Http.StringContent(json_);
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("POST");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<UsedTicketResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("Invalid credentials", status_, responseText_, headers_, null);
+                        }
+                        else
+                        if (status_ == 403)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ApiError>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ApiError>("User has no tickets for the product or the menu item is not eligible for the ticket", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ApiError>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ApiError>("The product or menu item could not be found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         {
@@ -2883,6 +3362,57 @@ namespace Shifty.Api.Generated.AnalogCoreV2
     }
 
     /// <summary>
+    /// Represents a menu item that can be redeemed with a ticket
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
+    public partial class MenuItemResponse
+    {
+        /// <summary>
+        /// Id of menu item
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Always)]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Name of menu item
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        public string Name { get; set; }
+
+    }
+
+    /// <summary>
+    /// Initiate a new menuitem add request.
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
+    public partial class AddMenuItemRequest
+    {
+        /// <summary>
+        /// Gets or sets the name of the product.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        public string Name { get; set; }
+
+    }
+
+    /// <summary>
+    /// Initiate an update product request.
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
+    public partial class UpdateMenuItemRequest
+    {
+        /// <summary>
+        /// Gets or sets the updated name of the product.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        public string Name { get; set; }
+
+    }
+
+    /// <summary>
     /// MobilePay webhook invocation request 
     /// <br/>Code documentation based on MobilePay Developer: Webhooks
     /// </summary>
@@ -2995,6 +3525,13 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         [System.ComponentModel.DataAnnotations.Required]
         public System.Collections.Generic.ICollection<UserGroup> AllowedUserGroups { get; set; } = new System.Collections.ObjectModel.Collection<UserGroup>();
 
+        /// <summary>
+        /// Gets or sets the eligibible menu items for the product.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("menuItems", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<MenuItemResponse> MenuItems { get; set; } = new System.Collections.ObjectModel.Collection<MenuItemResponse>();
+
     }
 
     /// <summary>
@@ -3034,7 +3571,7 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         /// <summary>
         /// Gets or sets the visibility of the product. Default is true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("visible", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("visible", Required = Newtonsoft.Json.Required.Always)]
         public bool Visible { get; set; } = true;
 
         /// <summary>
@@ -3043,6 +3580,13 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         [Newtonsoft.Json.JsonProperty("allowedUserGroups", Required = Newtonsoft.Json.Required.Always, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         [System.ComponentModel.DataAnnotations.Required]
         public System.Collections.Generic.ICollection<UserGroup> AllowedUserGroups { get; set; } = new System.Collections.ObjectModel.Collection<UserGroup>();
+
+        /// <summary>
+        /// Gets or sets the menu items that are eligible for the product.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("menuItemIds", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<int> MenuItemIds { get; set; } = new System.Collections.ObjectModel.Collection<int>();
 
     }
 
@@ -3089,7 +3633,7 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         /// <summary>
         /// Gets or sets the updated visibility of the product. Default is true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("visible", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("visible", Required = Newtonsoft.Json.Required.Always)]
         public bool Visible { get; set; } = true;
 
         /// <summary>
@@ -3098,6 +3642,13 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         [Newtonsoft.Json.JsonProperty("allowedUserGroups", Required = Newtonsoft.Json.Required.Always, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         [System.ComponentModel.DataAnnotations.Required]
         public System.Collections.Generic.ICollection<UserGroup> AllowedUserGroups { get; set; } = new System.Collections.ObjectModel.Collection<UserGroup>();
+
+        /// <summary>
+        /// Gets or sets the eligible menu items for the product.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("menuItemIds", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<int> MenuItemIds { get; set; } = new System.Collections.ObjectModel.Collection<int>();
 
     }
 
@@ -3157,6 +3708,12 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         [Newtonsoft.Json.JsonProperty("allowedUserGroups", Required = Newtonsoft.Json.Required.Always, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         [System.ComponentModel.DataAnnotations.Required]
         public System.Collections.Generic.ICollection<UserGroup> AllowedUserGroups { get; set; } = new System.Collections.ObjectModel.Collection<UserGroup>();
+
+        /// <summary>
+        /// The menu items that this product can be used on.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("eligibleMenuItems", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<MenuItemResponse> EligibleMenuItems { get; set; }
 
     }
 
@@ -3287,7 +3844,7 @@ namespace Shifty.Api.Generated.AnalogCoreV2
     [JsonInheritanceAttribute("MobilePayPaymentDetails", typeof(MobilePayPaymentDetails))]
     [JsonInheritanceAttribute("FreePurchasePaymentDetails", typeof(FreePurchasePaymentDetails))]
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
-    public partial class PaymentDetails
+    public abstract partial class PaymentDetails
     {
         /// <summary>
         /// Payment type
@@ -3475,6 +4032,73 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         [Newtonsoft.Json.JsonProperty("productName", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required]
         public string ProductName { get; set; }
+
+        /// <summary>
+        /// The name of the menu item that this ticket was used on
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("usedOnMenuItemName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string UsedOnMenuItemName { get; set; }
+
+    }
+
+    /// <summary>
+    /// Representing a used ticket for a product
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
+    public partial class UsedTicketResponse
+    {
+        /// <summary>
+        /// Ticket Id
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Always)]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Issuing date time for ticket in Utc format
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("dateCreated", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.DateTimeOffset DateCreated { get; set; }
+
+        /// <summary>
+        /// Used date time for ticket in Utc format
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("dateUsed", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.DateTimeOffset DateUsed { get; set; }
+
+        /// <summary>
+        /// Name of product a ticket is for
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("productName", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        public string ProductName { get; set; }
+
+        /// <summary>
+        /// Name of the menu item that this ticket was used on
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("menuItemName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string MenuItemName { get; set; }
+
+    }
+
+    /// <summary>
+    /// Represents a request to use a ticket.
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
+    public partial class UseTicketRequest
+    {
+        /// <summary>
+        /// The id of the product the ticket is for.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("productId", Required = Newtonsoft.Json.Required.Always)]
+        public int ProductId { get; set; }
+
+        /// <summary>
+        /// The id of the menu item to use the ticket on.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("menuItemId", Required = Newtonsoft.Json.Required.Always)]
+        public int MenuItemId { get; set; }
 
     }
 

--- a/Shifty.Api/Generated/AnalogCoreV2/AnalogCoreV2.cs
+++ b/Shifty.Api/Generated/AnalogCoreV2/AnalogCoreV2.cs
@@ -3844,7 +3844,7 @@ namespace Shifty.Api.Generated.AnalogCoreV2
     [JsonInheritanceAttribute("MobilePayPaymentDetails", typeof(MobilePayPaymentDetails))]
     [JsonInheritanceAttribute("FreePurchasePaymentDetails", typeof(FreePurchasePaymentDetails))]
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
-    public abstract partial class PaymentDetails
+    public partial class PaymentDetails
     {
         /// <summary>
         /// Payment type

--- a/Shifty.Api/Generated/AnalogCoreV2/AnalogCoreV2.cs
+++ b/Shifty.Api/Generated/AnalogCoreV2/AnalogCoreV2.cs
@@ -1631,24 +1631,24 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         }
 
         /// <summary>
-        /// Adds a new product to the database.
+        /// Adds a new product
         /// </summary>
-        /// <param name="addProductRequest">The request containing the details of the product to be added and allowed user groups.</param>
-        /// <returns>The request was successful, and the product was added.</returns>
+        /// <param name="addProductRequest">The request containing the details of the product to be added and allowed user groups</param>
+        /// <returns>The newly added product</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task<ChangedProductResponse> ApiV2ProductsPostAsync(AddProductRequest addProductRequest)
+        public virtual System.Threading.Tasks.Task<ProductResponse> ApiV2ProductsPostAsync(AddProductRequest addProductRequest)
         {
             return ApiV2ProductsPostAsync(addProductRequest, System.Threading.CancellationToken.None);
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Adds a new product to the database.
+        /// Adds a new product
         /// </summary>
-        /// <param name="addProductRequest">The request containing the details of the product to be added and allowed user groups.</param>
-        /// <returns>The request was successful, and the product was added.</returns>
+        /// <param name="addProductRequest">The request containing the details of the product to be added and allowed user groups</param>
+        /// <returns>The newly added product</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<ChangedProductResponse> ApiV2ProductsPostAsync(AddProductRequest addProductRequest, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task<ProductResponse> ApiV2ProductsPostAsync(AddProductRequest addProductRequest, System.Threading.CancellationToken cancellationToken)
         {
             if (addProductRequest == null)
                 throw new System.ArgumentNullException("addProductRequest");
@@ -1690,98 +1690,9 @@ namespace Shifty.Api.Generated.AnalogCoreV2
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 200)
+                        if (status_ == 201)
                         {
-                            var objectResponse_ = await ReadObjectResponseAsync<ChangedProductResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            return objectResponse_.Object;
-                        }
-                        else
-                        {
-                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
-                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
-                        }
-                    }
-                    finally
-                    {
-                        if (disposeResponse_)
-                            response_.Dispose();
-                    }
-                }
-            }
-            finally
-            {
-                if (disposeClient_)
-                    client_.Dispose();
-            }
-        }
-
-        /// <summary>
-        /// Updates a product with the specified changes.
-        /// </summary>
-        /// <param name="product">The request containing the changes to be applied to the product.</param>
-        /// <returns>The request was successful, and the product was updated.</returns>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task<ChangedProductResponse> ApiV2ProductsPutAsync(UpdateProductRequest product)
-        {
-            return ApiV2ProductsPutAsync(product, System.Threading.CancellationToken.None);
-        }
-
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <summary>
-        /// Updates a product with the specified changes.
-        /// </summary>
-        /// <param name="product">The request containing the changes to be applied to the product.</param>
-        /// <returns>The request was successful, and the product was updated.</returns>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<ChangedProductResponse> ApiV2ProductsPutAsync(UpdateProductRequest product, System.Threading.CancellationToken cancellationToken)
-        {
-            if (product == null)
-                throw new System.ArgumentNullException("product");
-
-            var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("api/v2/products");
-
-            var client_ = _httpClient;
-            var disposeClient_ = false;
-            try
-            {
-                using (var request_ = new System.Net.Http.HttpRequestMessage())
-                {
-                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(product, _settings.Value);
-                    var content_ = new System.Net.Http.StringContent(json_);
-                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
-                    request_.Content = content_;
-                    request_.Method = new System.Net.Http.HttpMethod("PUT");
-                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
-
-                    PrepareRequest(client_, request_, urlBuilder_);
-
-                    var url_ = urlBuilder_.ToString();
-                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
-
-                    PrepareRequest(client_, request_, url_);
-
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-                    var disposeResponse_ = true;
-                    try
-                    {
-                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
-                        if (response_.Content != null && response_.Content.Headers != null)
-                        {
-                            foreach (var item_ in response_.Content.Headers)
-                                headers_[item_.Key] = item_.Value;
-                        }
-
-                        ProcessResponse(client_, response_);
-
-                        var status_ = (int)response_.StatusCode;
-                        if (status_ == 200)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<ChangedProductResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            var objectResponse_ = await ReadObjectResponseAsync<ProductResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
@@ -1895,31 +1806,126 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         }
 
         /// <summary>
+        /// Updates a product with the specified changes.
+        /// </summary>
+        /// <param name="productId">Product Id</param>
+        /// <param name="product">The request containing the changes to be applied to the product</param>
+        /// <returns>The product was updated</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<ProductResponse> ApiV2ProductsPutAsync(int productId, UpdateProductRequest product)
+        {
+            return ApiV2ProductsPutAsync(productId, product, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Updates a product with the specified changes.
+        /// </summary>
+        /// <param name="productId">Product Id</param>
+        /// <param name="product">The request containing the changes to be applied to the product</param>
+        /// <returns>The product was updated</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<ProductResponse> ApiV2ProductsPutAsync(int productId, UpdateProductRequest product, System.Threading.CancellationToken cancellationToken)
+        {
+            if (productId == null)
+                throw new System.ArgumentNullException("productId");
+
+            if (product == null)
+                throw new System.ArgumentNullException("product");
+
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append("api/v2/products/{id}");
+            urlBuilder_.Replace("{id}", System.Uri.EscapeDataString(ConvertToString(productId, System.Globalization.CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(product, _settings.Value);
+                    var content_ = new System.Net.Http.StringContent(json_);
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("PUT");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProductResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <summary>
         /// Returns a product with the specified id
         /// </summary>
-        /// <param name="id">The id of the product to be returned</param>
+        /// <param name="productId">The id of the product to be returned</param>
         /// <returns>Successful request</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task<ProductResponse> ApiV2ProductsGetAsync(int id)
+        public virtual System.Threading.Tasks.Task<ProductResponse> ApiV2ProductsGetAsync(int productId)
         {
-            return ApiV2ProductsGetAsync(id, System.Threading.CancellationToken.None);
+            return ApiV2ProductsGetAsync(productId, System.Threading.CancellationToken.None);
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
         /// Returns a product with the specified id
         /// </summary>
-        /// <param name="id">The id of the product to be returned</param>
+        /// <param name="productId">The id of the product to be returned</param>
         /// <returns>Successful request</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<ProductResponse> ApiV2ProductsGetAsync(int id, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task<ProductResponse> ApiV2ProductsGetAsync(int productId, System.Threading.CancellationToken cancellationToken)
         {
-            if (id == null)
-                throw new System.ArgumentNullException("id");
+            if (productId == null)
+                throw new System.ArgumentNullException("productId");
 
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append("api/v2/products/{id}");
-            urlBuilder_.Replace("{id}", System.Uri.EscapeDataString(ConvertToString(id, System.Globalization.CultureInfo.InvariantCulture)));
+            urlBuilder_.Replace("{id}", System.Uri.EscapeDataString(ConvertToString(productId, System.Globalization.CultureInfo.InvariantCulture)));
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -3479,58 +3485,67 @@ namespace Shifty.Api.Generated.AnalogCoreV2
     }
 
     /// <summary>
-    /// Represents the product response.
+    /// Represents a purchasable product
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
-    public partial class ChangedProductResponse
+    public partial class ProductResponse
     {
         /// <summary>
-        /// Gets or sets the price of the product.
+        /// Id of product
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Always)]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Product price
         /// </summary>
         [Newtonsoft.Json.JsonProperty("price", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Range(0, 2147483647)]
         public int Price { get; set; }
 
         /// <summary>
-        /// Gets or sets the number of tickets associated with the product.
+        /// Number of tickets in product
         /// </summary>
         [Newtonsoft.Json.JsonProperty("numberOfTickets", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Range(0, 2147483647)]
         public int NumberOfTickets { get; set; }
 
         /// <summary>
-        /// Gets or sets the name of the product.
+        /// Name of product
         /// </summary>
         [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required]
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets the description of the product.
+        /// Description of products
         /// </summary>
         [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required]
         public string Description { get; set; }
 
         /// <summary>
-        /// Gets or sets the visibility of the product.
+        /// Eligible due to a user perk privilege 
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isPerk", Required = Newtonsoft.Json.Required.Always)]
+        public bool IsPerk { get; set; }
+
+        /// <summary>
+        /// Visibility of products for users
         /// </summary>
         [Newtonsoft.Json.JsonProperty("visible", Required = Newtonsoft.Json.Required.Always)]
         public bool Visible { get; set; }
 
         /// <summary>
-        /// Gets or sets the user groups that can access the product.
+        /// Decides the user groups that can access the product.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("allowedUserGroups", Required = Newtonsoft.Json.Required.Always, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         [System.ComponentModel.DataAnnotations.Required]
         public System.Collections.Generic.ICollection<UserGroup> AllowedUserGroups { get; set; } = new System.Collections.ObjectModel.Collection<UserGroup>();
 
         /// <summary>
-        /// Gets or sets the eligibible menu items for the product.
+        /// The menu items that this product can be used on.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("menuItems", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
-        public System.Collections.Generic.ICollection<MenuItemResponse> MenuItems { get; set; } = new System.Collections.ObjectModel.Collection<MenuItemResponse>();
+        [Newtonsoft.Json.JsonProperty("eligibleMenuItems", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<MenuItemResponse> EligibleMenuItems { get; set; }
 
     }
 
@@ -3597,12 +3612,6 @@ namespace Shifty.Api.Generated.AnalogCoreV2
     public partial class UpdateProductRequest
     {
         /// <summary>
-        /// Gets or sets the ID of the product to update.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Always)]
-        public int Id { get; set; }
-
-        /// <summary>
         /// Gets or sets the updated price of the product.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("price", Required = Newtonsoft.Json.Required.Always)]
@@ -3649,71 +3658,6 @@ namespace Shifty.Api.Generated.AnalogCoreV2
         [Newtonsoft.Json.JsonProperty("menuItemIds", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required]
         public System.Collections.Generic.ICollection<int> MenuItemIds { get; set; } = new System.Collections.ObjectModel.Collection<int>();
-
-    }
-
-    /// <summary>
-    /// Represents a purchasable product
-    /// </summary>
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v10.0.0.0))")]
-    public partial class ProductResponse
-    {
-        /// <summary>
-        /// Id of product
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Always)]
-        public int Id { get; set; }
-
-        /// <summary>
-        /// Product price
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("price", Required = Newtonsoft.Json.Required.Always)]
-        public int Price { get; set; }
-
-        /// <summary>
-        /// Number of tickets in product
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("numberOfTickets", Required = Newtonsoft.Json.Required.Always)]
-        public int NumberOfTickets { get; set; }
-
-        /// <summary>
-        /// Name of product
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
-        public string Name { get; set; }
-
-        /// <summary>
-        /// Description of products
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
-        public string Description { get; set; }
-
-        /// <summary>
-        /// Eligible due to a user perk privilege 
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("isPerk", Required = Newtonsoft.Json.Required.Always)]
-        public bool IsPerk { get; set; }
-
-        /// <summary>
-        /// Visibility of products for users
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("visible", Required = Newtonsoft.Json.Required.Always)]
-        public bool Visible { get; set; }
-
-        /// <summary>
-        /// Decides the user groups that can access the product.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("allowedUserGroups", Required = Newtonsoft.Json.Required.Always, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        [System.ComponentModel.DataAnnotations.Required]
-        public System.Collections.Generic.ICollection<UserGroup> AllowedUserGroups { get; set; } = new System.Collections.ObjectModel.Collection<UserGroup>();
-
-        /// <summary>
-        /// The menu items that this product can be used on.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("eligibleMenuItems", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.ICollection<MenuItemResponse> EligibleMenuItems { get; set; }
 
     }
 

--- a/Shifty.App/Components/MenuItems.razor
+++ b/Shifty.App/Components/MenuItems.razor
@@ -1,0 +1,28 @@
+@namespace Components
+@using System.ComponentModel.DataAnnotations
+@using Shifty.App.Services
+@using Shifty.Api.Generated.AnalogCoreV1
+@using Shifty.Api.Generated.AnalogCoreV2
+@using Shared
+@using LanguageExt.UnsafeValueAccess
+@using Shifty.App.Repositories
+@inject ISnackbar Snackbar
+@inject IJSRuntime JSRuntime
+
+<MudPaper Elevation="15" Style="margin: 2em; border-radius: 5px;">
+    @if (_loading)
+    {
+        <MudContainer Style="width: 100%; display: flex;">
+            <LoadingIndicator Height="400px" />
+        </MudContainer>
+    }
+</MudPaper>
+
+@code
+{
+    private bool _loading = true;
+
+    protected override async Task OnInitializedAsync()
+    {
+    }
+}

--- a/Shifty.App/Components/ProductManager.razor
+++ b/Shifty.App/Components/ProductManager.razor
@@ -8,6 +8,7 @@
 @using LanguageExt.UnsafeValueAccess
 @using Components
 @using Shifty.App.DomainModels
+@using System.Collections.ObjectModel
 @inject ISnackbar Snackbar
 @inject IProductService ProductService
 @inject IJSRuntime JSRuntime
@@ -127,7 +128,7 @@
 @code
 {
     private MudDataGrid<Product> _dataGrid;
-    private IEnumerable<Product> _products = new List<Product>();
+    private ObservableCollection<Product> _products = new ObservableCollection<Product>();
     private Dictionary<UserGroup, bool> UserGroupDict = new();
     private IEnumerable<MenuItem> _allMenuItems = new List<MenuItem>();
     private Dictionary<MenuItem, bool> SelectedMenuItems = new();
@@ -148,7 +149,8 @@
         var productsResult = await ProductService.GetProducts();
         productsResult.Match(
             Succ: products => {
-                _products = products;
+                _products = new ObservableCollection<Product>(products);
+                StateHasChanged();
             },
             Fail: error => {
                 Snackbar.Add(error.Message, Severity.Error);
@@ -194,22 +196,16 @@
             var result = await ProductService.AddProduct(item);
 
             result.Match(
-                Succ: async product =>
+                Succ: product =>
                 {
                     // Succesfully added product
                     Snackbar.Add("Product added", Severity.Success);
 
-                    // Retrieve all items again in order to update id
-                    var retrieveItems = await ProductService.GetProducts();
-                    retrieveItems.Match(
-                        Succ: items => {
-                            _products = items;
-                        },
-                        Fail: error => {
-                            // Errors while re-retrieving items, non-fatal (just means _products are slightly outdated)
-                            Snackbar.Add(error.Message, Severity.Warning);
-                        }
-                    );
+                    // Override the created product with the placeholder item
+                    _products.Remove(item);
+                    _products.Add(product);
+                    
+                    StateHasChanged();
                 },
                 Fail: error => {
                     Snackbar.Add(error.Message, Severity.Error);
@@ -221,20 +217,10 @@
             var result = await ProductService.UpdateProduct(item, item.Id);
 
             result.Match(
-                Succ: async result =>
+                Succ: product =>
                 {
                     Snackbar.Add("Product updated", Severity.Success);
-
-                    var retrieveItems = await ProductService.GetProducts();
-                    retrieveItems.Match(
-                        Succ: items => {
-                            _products = items;
-                        },
-                        Fail: error => {
-                            // Errors while re-retrieving items, non-fatal (just means _products are slightly outdated)
-                            Snackbar.Add(error.Message, Severity.Warning);
-                        }
-                    );
+                    _products.FirstOrDefault(p => p.Id == item.Id).IsPerk = product.IsPerk;
                 },
                 Fail: error =>
                 {
@@ -246,7 +232,7 @@
 
     void AddItemToDataGrid()
     {
-        _products = _products.Append<Product>(new Product{
+        _products.Add(new Product{
             Id = 0,
             Name = "",
             Description = "",
@@ -254,8 +240,10 @@
             NumberOfTickets = 1,
             Price = 0,
             Visible = true,
-            AllowedUserGroups = new List<UserGroup>()
+            AllowedUserGroups = new List<UserGroup>(),
+            EligibleMenuItems = new List<MenuItem>(),
         });
+        StateHasChanged();
         _dataGrid.SetEditingItemAsync(_products.Last());
     }
 

--- a/Shifty.App/Components/ProductManager.razor
+++ b/Shifty.App/Components/ProductManager.razor
@@ -37,7 +37,7 @@
         CommittedItemChanges="@CommittedItemChanges"
         EditTrigger="DataGridEditTrigger.Manual"
         QuickFilter="e => _showNonvisible || e.Visible"
-        RowStyleFunc="@_RowStyleFunc"
+        RowStyleFunc="@RowStyleFunc"
         FixedHeader="true"
         Height="calc(100vh - 250px)"
         Dense="true"
@@ -131,7 +131,7 @@
     private IEnumerable<Product> _products = new List<Product>();
     private Dictionary<UserGroup, bool> UserGroupDict = new();
     private IEnumerable<MenuItem> _allMenuItems = new List<MenuItem>();
-    private Dictionary<MenuItem, bool> SelectedMenuItems = new();
+    
     private void StartedEditingItem(Product item)
     {
         UserGroupDict = new();
@@ -247,7 +247,7 @@
         _dataGrid.SetEditingItemAsync(_products.Last());
     }
 
-    private Func<Product, int, string> _RowStyleFunc => (x, i) =>
+    private Func<Product, int, string> RowStyleFunc => (x, i) =>
     {
         if (!x.Visible)
         {

--- a/Shifty.App/Components/ProductManager.razor
+++ b/Shifty.App/Components/ProductManager.razor
@@ -1,5 +1,6 @@
 @namespace Components
 @using System.ComponentModel.DataAnnotations
+@using MudExtensions
 @using Shifty.App.Services
 @using Shifty.Api.Generated.AnalogCoreV1
 @using Shifty.Api.Generated.AnalogCoreV2
@@ -101,12 +102,12 @@
             <PropertyColumn Property="x => x.Description" Title="Description" IsEditable="true" />
             <PropertyColumn Property="x => x.EligibleMenuItems" Title="Eligible menu items" IsEditable="true" Hidden>
                 <EditTemplate>
-                    <MudText Typo="Typo.subtitle1">Eligible menu items:</MudText>
-                    @foreach (var mi in _allMenuItems)
-                    {
-                        <MudCheckBox Dense="true" Color="Color.Primary" @bind-Checked="SelectedMenuItems[mi]" Value="@mi">
-                            @mi.Name</MudCheckBox>
-                    }
+                    <MudComboBox Label="Eligible menu items" T="MenuItem" MultiSelection="true" Editable="true" @bind-SelectedValues="context.Item.EligibleMenuItems">
+                        @foreach (var mi in _allMenuItems)
+                        {
+                            <MudComboBoxItem Text="@mi.Name" Value="@mi">@mi.Name</MudComboBoxItem>
+                        }
+                    </MudComboBox>
                 </EditTemplate>
             </PropertyColumn>
         </Columns>
@@ -137,11 +138,6 @@
         {
             UserGroupDict.Add(group, item.AllowedUserGroups.Contains(group));
         }
-
-        foreach (var mi in _allMenuItems)
-        {
-            SelectedMenuItems[mi] = item.EligibleMenuItems.Contains(mi);
-        }
         FocusFirst();
     }
 
@@ -164,10 +160,6 @@
         menuItemsResult.Match(
             Succ: menuItems => {
                 _allMenuItems = menuItems;
-                foreach (var mi in menuItems)
-                {
-                    SelectedMenuItems.Add(mi, false);
-                }
             },
             Fail: error => {
                 Snackbar.Add(error.Message, Severity.Error);
@@ -196,15 +188,6 @@
                              .ToList();
         
         item.AllowedUserGroups = AllowedUserGroups;
-
-        List<MenuItem> EligibleMenuItems =
-                SelectedMenuItems.Where(e => e.Value)
-                                 .ToDictionary(kv => kv.Key, kv => kv.Value)
-                                 .Keys
-                                 .ToList();
-
-        item.EligibleMenuItems = EligibleMenuItems;
-
 
         if (item.Id == 0)
         {

--- a/Shifty.App/Components/ProductManager.razor
+++ b/Shifty.App/Components/ProductManager.razor
@@ -182,16 +182,12 @@
         Snackbar.Add("Cancelled product changes", Severity.Info);
     }
 
-<<<<<<< HEAD
     async Task FocusFirst()
     {
         await JSRuntime.InvokeVoidAsync("window.focusElement", "first-edit-element");
     }
 
-    async Task CommittedItemChanges(ProductResponse item)
-=======
     async Task CommittedItemChanges(Product item)
->>>>>>> 59310e7 (Adds menu items property to products)
     {
         List<UserGroup> AllowedUserGroups =
                 UserGroupDict.Where(e => e.Value)

--- a/Shifty.App/Components/ProductManager.razor
+++ b/Shifty.App/Components/ProductManager.razor
@@ -6,9 +6,11 @@
 @using Shared
 @using LanguageExt.UnsafeValueAccess
 @using Components
+@using Shifty.App.DomainModels
 @inject ISnackbar Snackbar
 @inject IProductService ProductService
 @inject IJSRuntime JSRuntime
+@inject IMenuItemService MenuItemService
 
 <style>
     .mud-table-cell {
@@ -24,7 +26,7 @@
     }
     <MudDataGrid
         @ref="_dataGrid"
-        T="ProductResponse"
+        T="Product"
         Items="@_products"
         EditMode="DataGridEditMode.Form"
         ReadOnly="false"
@@ -97,6 +99,16 @@
                 </CellTemplate>
             </PropertyColumn>
             <PropertyColumn Property="x => x.Description" Title="Description" IsEditable="true" />
+            <PropertyColumn Property="x => x.EligibleMenuItems" Title="Eligible menu items" IsEditable="true" Hidden>
+                <EditTemplate>
+                    <MudText Typo="Typo.subtitle1">Eligible menu items:</MudText>
+                    @foreach (var mi in _allMenuItems)
+                    {
+                        <MudCheckBox Dense="true" Color="Color.Primary" @bind-Checked="SelectedMenuItems[mi]" Value="@mi">
+                            @mi.Name</MudCheckBox>
+                    }
+                </EditTemplate>
+            </PropertyColumn>
         </Columns>
     </MudDataGrid>
 
@@ -113,16 +125,22 @@
 </MudPaper>
 @code
 {
-    private MudDataGrid<ProductResponse> _dataGrid;
-    private IEnumerable<ProductResponse> _products = new List<ProductResponse>();
+    private MudDataGrid<Product> _dataGrid;
+    private IEnumerable<Product> _products = new List<Product>();
     private Dictionary<UserGroup, bool> UserGroupDict = new();
-
-    private void StartedEditingItem(ProductResponse item)
+    private IEnumerable<MenuItem> _allMenuItems = new List<MenuItem>();
+    private Dictionary<MenuItem, bool> SelectedMenuItems = new();
+    private void StartedEditingItem(Product item)
     {
         UserGroupDict = new();
         foreach (var group in Enum.GetValues<UserGroup>())
         {
             UserGroupDict.Add(group, item.AllowedUserGroups.Contains(group));
+        }
+
+        foreach (var mi in _allMenuItems)
+        {
+            SelectedMenuItems[mi] = item.EligibleMenuItems.Contains(mi);
         }
         FocusFirst();
     }
@@ -131,9 +149,8 @@
     private bool _showNonvisible = true;
     protected override async Task OnInitializedAsync()
     {
-        var result = await ProductService.GetProducts();
-        _loading = false;
-        result.Match(
+        var productsResult = await ProductService.GetProducts();
+        productsResult.Match(
             Succ: products => {
                 _products = products;
             },
@@ -141,29 +158,61 @@
                 Snackbar.Add(error.Message, Severity.Error);
             }
         );
+
+        var menuItemsResult = await MenuItemService.GetMenuItems();
+
+        menuItemsResult.Match(
+            Succ: menuItems => {
+                _allMenuItems = menuItems;
+                foreach (var mi in menuItems)
+                {
+                    SelectedMenuItems.Add(mi, false);
+                }
+            },
+            Fail: error => {
+                Snackbar.Add(error.Message, Severity.Error);
+            }
+        );
+
+        _loading = false;
     }
 
-    void CanceledEditingItem(ProductResponse item)
+    void CanceledEditingItem(Product item)
     {
         Snackbar.Add("Cancelled product changes", Severity.Info);
     }
 
+<<<<<<< HEAD
     async Task FocusFirst()
     {
         await JSRuntime.InvokeVoidAsync("window.focusElement", "first-edit-element");
     }
 
     async Task CommittedItemChanges(ProductResponse item)
+=======
+    async Task CommittedItemChanges(Product item)
+>>>>>>> 59310e7 (Adds menu items property to products)
     {
         List<UserGroup> AllowedUserGroups =
                 UserGroupDict.Where(e => e.Value)
                              .ToDictionary(kv => kv.Key, kv => kv.Value)
                              .Keys
                              .ToList();
+        
+        item.AllowedUserGroups = AllowedUserGroups;
+
+        List<MenuItem> EligibleMenuItems =
+                SelectedMenuItems.Where(e => e.Value)
+                                 .ToDictionary(kv => kv.Key, kv => kv.Value)
+                                 .Keys
+                                 .ToList();
+
+        item.EligibleMenuItems = EligibleMenuItems;
+
 
         if (item.Id == 0)
         {
-            var result = await addProduct(item, AllowedUserGroups);
+            var result = await ProductService.AddProduct(item);
 
             result.Match(
                 Succ: async product =>
@@ -190,7 +239,7 @@
         }
         else
         {
-            var result = await updateProduct(item, AllowedUserGroups);
+            var result = await ProductService.UpdateProduct(item, item.Id);
 
             result.Match(
                 Succ: async result =>
@@ -216,36 +265,9 @@
         }
     }
 
-    async Task<LanguageExt.Try<ChangedProductResponse>> updateProduct(ProductResponse item, List<UserGroup>
-    AllowedUserGroups)
-    {
-        return await ProductService.UpdateProduct(new UpdateProductRequest{
-                Id = item.Id,
-                Name = item.Name,
-                Description = item.Description,
-                NumberOfTickets = item.NumberOfTickets,
-                Price = item.Price,
-                Visible = item.Visible,
-                AllowedUserGroups = AllowedUserGroups
-            });
-    }
-
-    async Task<LanguageExt.Try<ChangedProductResponse>> addProduct(ProductResponse item, List<UserGroup>
-    AllowedUserGroups)
-    {
-        return await ProductService.AddProduct(new AddProductRequest{
-                Name = item.Name,
-                Description = item.Description,
-                NumberOfTickets = item.NumberOfTickets,
-                Price = item.Price,
-                Visible = item.Visible,
-                AllowedUserGroups = AllowedUserGroups
-            });
-    }
-
     void AddItemToDataGrid()
     {
-        _products = _products.Append<ProductResponse>(new ProductResponse{
+        _products = _products.Append<Product>(new Product{
             Id = 0,
             Name = "",
             Description = "",
@@ -258,7 +280,7 @@
         _dataGrid.SetEditingItemAsync(_products.Last());
     }
 
-    private Func<ProductResponse, int, string> _RowStyleFunc => (x, i) =>
+    private Func<Product, int, string> _RowStyleFunc => (x, i) =>
     {
         if (!x.Visible)
         {

--- a/Shifty.App/Components/ProductManager.razor
+++ b/Shifty.App/Components/ProductManager.razor
@@ -128,7 +128,7 @@
 @code
 {
     private MudDataGrid<Product> _dataGrid;
-    private ObservableCollection<Product> _products = new ObservableCollection<Product>();
+    private IEnumerable<Product> _products = new List<Product>();
     private Dictionary<UserGroup, bool> UserGroupDict = new();
     private IEnumerable<MenuItem> _allMenuItems = new List<MenuItem>();
     private Dictionary<MenuItem, bool> SelectedMenuItems = new();
@@ -149,7 +149,7 @@
         var productsResult = await ProductService.GetProducts();
         productsResult.Match(
             Succ: products => {
-                _products = new ObservableCollection<Product>(products);
+                _products = new List<Product>(products);
                 StateHasChanged();
             },
             Fail: error => {
@@ -202,8 +202,8 @@
                     Snackbar.Add("Product added", Severity.Success);
 
                     // Override the created product with the placeholder item
-                    _products.Remove(item);
-                    _products.Add(product);
+                    _products = _products.Where(p => p.Id != 0)
+                                .Append(product);
                     
                     StateHasChanged();
                 },
@@ -232,7 +232,7 @@
 
     void AddItemToDataGrid()
     {
-        _products.Add(new Product{
+        _products = _products.Append(new Product{
             Id = 0,
             Name = "",
             Description = "",

--- a/Shifty.App/Components/ProductManager.razor
+++ b/Shifty.App/Components/ProductManager.razor
@@ -103,7 +103,12 @@
             <PropertyColumn Property="x => x.Description" Title="Description" IsEditable="true" />
             <PropertyColumn Property="x => x.EligibleMenuItems" Title="Eligible menu items" IsEditable="true" Hidden>
                 <EditTemplate>
-                    <MudComboBox Label="Eligible menu items" T="MenuItem" MultiSelection="true" Editable="true" @bind-SelectedValues="context.Item.EligibleMenuItems">
+                    <MudComboBox
+                        T="MenuItem" 
+                        Label="Eligible menu items"
+                        MultiSelection="true" 
+                        Editable="true" 
+                        @bind-SelectedValues="context.Item.EligibleMenuItems">
                         @foreach (var mi in _allMenuItems)
                         {
                             <MudComboBoxItem Text="@mi.Name" Value="@mi">@mi.Name</MudComboBoxItem>

--- a/Shifty.App/Components/Voucher.razor
+++ b/Shifty.App/Components/Voucher.razor
@@ -6,6 +6,7 @@
 @using Shared
 @using LanguageExt.UnsafeValueAccess
 @using Shifty.App.Repositories
+@using Shifty.App.DomainModels
 @inject IProductService _productService
 @inject IVoucherService _voucherService
 @inject ISnackbar Snackbar
@@ -16,7 +17,7 @@
         <MudCardContent>
             <MudText Align="Align.Center" Class="mb-n4">Issue Voucher Form</MudText>
             <MudForm @bind-IsValid="@_isFormValid" >
-                <MudAutocomplete T="ProductResponse"
+                <MudAutocomplete T="Product"
                                  Required="true"
                                  RequiredError="Product is required"
                                  Placeholder="Select product"
@@ -100,7 +101,7 @@
     private VoucherForm _voucherForm = new();
     private bool _isFormValid = false;
     private bool _showProgressBar = false;
-    private IEnumerable<ProductResponse> _products = new List<ProductResponse>();
+    private IEnumerable<Product> _products = new List<Product>();
     private IEnumerable<IssueVoucherResponse> _vouchers;
     private string _voucherCodes;
     private MudTextField<string> _multilineReference;
@@ -109,7 +110,7 @@
     {
         [Required]
         public string Description { get; set; }
-        public ProductResponse Product { get; set; }
+        public Product Product { get; set; }
         public int Amount { get; set; } = 1;
         public string Requester { get; set; }
         public string Prefix { get; set; }
@@ -130,7 +131,7 @@
         );
     }
 
-    private async Task<IEnumerable<ProductResponse>> Products(string value)
+    private async Task<IEnumerable<Product>> Products(string value)
     {
         if (string.IsNullOrEmpty(value))
             return _products;
@@ -168,6 +169,6 @@
         );
     }
     
-    Func<ProductResponse,string> _converter = p => p != null ? $"{p.Name} - {p.NumberOfTickets} ticket" + (p.NumberOfTickets == 1 ? "" : "s") : "";
+    Func<Product,string> _converter = p => p != null ? $"{p.Name} - {p.NumberOfTickets} ticket" + (p.NumberOfTickets == 1 ? "" : "s") : "";
     Func<string, string> _prefixValidation = str => str.Length == 3 ? null : "Prefix must be 3 letters";
 }

--- a/Shifty.App/Components/Voucher.razor
+++ b/Shifty.App/Components/Voucher.razor
@@ -122,7 +122,7 @@
 
         result.Match(
             Succ: products => {
-                _products = products.Filter<ProductResponse>(p => p.Visible);
+                _products = products.Filter<Product>(p => p.Visible);
                 _voucherForm.Prefix = User.Claims.Single(el => el.Type.Contains("email")).Value[..3].ToUpper();
             },
             Fail: error => {

--- a/Shifty.App/DomainModels/MenuItem.cs
+++ b/Shifty.App/DomainModels/MenuItem.cs
@@ -40,6 +40,10 @@ namespace Shifty.App.DomainModels
 
         public override bool Equals(object obj)
         {
+            if (obj is not MenuItem)
+            {
+                return false;
+            }
             return ((MenuItem)obj).Id == Id;
         }
 

--- a/Shifty.App/DomainModels/MenuItem.cs
+++ b/Shifty.App/DomainModels/MenuItem.cs
@@ -1,7 +1,4 @@
-<<<<<<< HEAD
 using System;
-=======
->>>>>>> 6cf5857 (Adds MenuItem service and repository)
 using System.Data.Common;
 using Shifty.Api.Generated.AnalogCoreV1;
 using Shifty.Api.Generated.AnalogCoreV2;

--- a/Shifty.App/DomainModels/MenuItem.cs
+++ b/Shifty.App/DomainModels/MenuItem.cs
@@ -5,7 +5,7 @@ using Shifty.Api.Generated.AnalogCoreV2;
 
 namespace Shifty.App.DomainModels
 {
-    public class MenuItem {
+    public record MenuItem {
         public int Id { get; init; }
         public string Name { get; set; }
         public static MenuItem FromDto(MenuItemResponse dto)
@@ -31,20 +31,6 @@ namespace Shifty.App.DomainModels
             {
                 Name = menuItem.Name
             };
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (obj is not MenuItem)
-            {
-                return false;
-            }
-            return ((MenuItem)obj).Id == Id;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Id, Name);
         }
     }
 }

--- a/Shifty.App/DomainModels/MenuItem.cs
+++ b/Shifty.App/DomainModels/MenuItem.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Data.Common;
+using Shifty.Api.Generated.AnalogCoreV1;
+using Shifty.Api.Generated.AnalogCoreV2;
+
+namespace Shifty.App.DomainModels
+{
+    public class MenuItem {
+        public int Id { get; init; }
+        public string Name { get; set; }
+        public static MenuItem FromDto(MenuItemResponse dto)
+        {
+            return new MenuItem()
+            {
+                Id = dto.Id,
+                Name = dto.Name
+            };
+        }
+
+        public static AddMenuItemRequest ToAddRequest(MenuItem menuItem)
+        {
+            return new AddMenuItemRequest()
+            {
+                Name = menuItem.Name
+            };
+        }
+
+        public static UpdateMenuItemRequest ToUpdateRequest(MenuItem menuItem)
+        {
+            return new UpdateMenuItemRequest()
+            {
+                Name = menuItem.Name
+            };
+        }
+
+        public override string ToString()
+        {
+            return Name;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return ((MenuItem)obj).Id == Id;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Id, Name);
+        }
+    }
+}

--- a/Shifty.App/DomainModels/MenuItem.cs
+++ b/Shifty.App/DomainModels/MenuItem.cs
@@ -1,4 +1,7 @@
+<<<<<<< HEAD
 using System;
+=======
+>>>>>>> 6cf5857 (Adds MenuItem service and repository)
 using System.Data.Common;
 using Shifty.Api.Generated.AnalogCoreV1;
 using Shifty.Api.Generated.AnalogCoreV2;

--- a/Shifty.App/DomainModels/MenuItem.cs
+++ b/Shifty.App/DomainModels/MenuItem.cs
@@ -33,11 +33,6 @@ namespace Shifty.App.DomainModels
             };
         }
 
-        public override string ToString()
-        {
-            return Name;
-        }
-
         public override bool Equals(object obj)
         {
             if (obj is not MenuItem)

--- a/Shifty.App/DomainModels/Product.cs
+++ b/Shifty.App/DomainModels/Product.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using System.Linq;
+using Shifty.Api.Generated.AnalogCoreV2;
+
+namespace Shifty.App.DomainModels
+{
+    public class Product {
+        public int Id { get; init; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public int Price { get; init; }
+        public int NumberOfTickets { get; set; }
+        public IEnumerable<MenuItem> EligibleMenuItems { get; set; }
+        public IEnumerable<UserGroup> AllowedUserGroups { get; set; }
+        public bool Visible { get; set; }
+        public bool IsPerk { get; set; }
+        public static Product FromDto(ProductResponse dto)
+        {
+            return new Product()
+            {
+                Id = dto.Id,
+                Name = dto.Name,
+                Price = dto.Price,
+                Description = dto.Description,
+                NumberOfTickets = dto.NumberOfTickets,
+                EligibleMenuItems = dto.EligibleMenuItems.Map(MenuItem.FromDto),
+                AllowedUserGroups = dto.AllowedUserGroups,
+                Visible = dto.Visible,
+                IsPerk = dto.IsPerk
+            };
+        }
+        public static Product FromChangedProduct(ChangedProductResponse dto, int id, bool isPerk)
+        {
+            return new Product()
+            {
+                Name = dto.Name,
+                Price = dto.Price,
+                Description = dto.Description,
+                NumberOfTickets = dto.NumberOfTickets,
+                EligibleMenuItems = dto.MenuItems.Map(MenuItem.FromDto),
+                AllowedUserGroups = dto.AllowedUserGroups,
+                Visible = dto.Visible,
+                Id = id,
+                IsPerk = isPerk
+            };
+        }
+
+        public static AddProductRequest ToAddRequest(Product product)
+        {
+            return new AddProductRequest()
+            {
+                Name = product.Name,
+                Description = product.Description,
+                NumberOfTickets = product.NumberOfTickets,
+                MenuItemIds = product.EligibleMenuItems.Map(x => x.Id).ToList(),
+                AllowedUserGroups = product.AllowedUserGroups.ToList(),
+                Visible = product.Visible,
+                Price = product.Price,
+            };
+        }
+
+        public static UpdateProductRequest ToUpdateRequest(Product product)
+        {
+            return new UpdateProductRequest()
+            {
+                Name = product.Name,
+                Description = product.Description,
+                NumberOfTickets = product.NumberOfTickets,
+                MenuItemIds = product.EligibleMenuItems.Map(x => x.Id).ToList(),
+                AllowedUserGroups = product.AllowedUserGroups.ToList(),
+                Visible = product.Visible,
+                Price = product.Price,
+                Id = product.Id,
+            };
+        }
+
+        public override string ToString()
+        {
+            return Name;
+        }
+    }
+}

--- a/Shifty.App/DomainModels/Product.cs
+++ b/Shifty.App/DomainModels/Product.cs
@@ -57,10 +57,5 @@ namespace Shifty.App.DomainModels
                 Price = product.Price,
             };
         }
-
-        public override string ToString()
-        {
-            return Name;
-        }
     }
 }

--- a/Shifty.App/DomainModels/Product.cs
+++ b/Shifty.App/DomainModels/Product.cs
@@ -29,21 +29,6 @@ namespace Shifty.App.DomainModels
                 IsPerk = dto.IsPerk
             };
         }
-        public static Product FromChangedProduct(ChangedProductResponse dto, int id, bool isPerk)
-        {
-            return new Product()
-            {
-                Name = dto.Name,
-                Price = dto.Price,
-                Description = dto.Description,
-                NumberOfTickets = dto.NumberOfTickets,
-                EligibleMenuItems = dto.MenuItems.Map(MenuItem.FromDto),
-                AllowedUserGroups = dto.AllowedUserGroups,
-                Visible = dto.Visible,
-                Id = id,
-                IsPerk = isPerk
-            };
-        }
 
         public static AddProductRequest ToAddRequest(Product product)
         {
@@ -70,7 +55,6 @@ namespace Shifty.App.DomainModels
                 AllowedUserGroups = product.AllowedUserGroups.ToList(),
                 Visible = product.Visible,
                 Price = product.Price,
-                Id = product.Id,
             };
         }
 

--- a/Shifty.App/Pages/MenuItem.razor
+++ b/Shifty.App/Pages/MenuItem.razor
@@ -1,0 +1,24 @@
+@page "/MenuItems"
+@using Components
+@inject NavigationManager NavManager
+
+@if (_user is not null && _user.IsInRole("Board"))
+{
+    <MenuItems />
+}
+
+@code {
+    [CascadingParameter] public Task<AuthenticationState> AuthTask { get; set; }
+    private System.Security.Claims.ClaimsPrincipal _user;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthTask;
+        _user = authState.User;
+
+        if (_user is null || !_user.IsInRole("Board"))
+        {
+            NavManager.NavigateTo("/");
+        }
+    }
+}

--- a/Shifty.App/Program.cs
+++ b/Shifty.App/Program.cs
@@ -13,6 +13,7 @@ using Shifty.Api.Generated.AnalogCoreV2;
 using Shifty.App.Authentication;
 using Shifty.App.Repositories;
 using Shifty.App.Services;
+using MudExtensions.Services;
 
 namespace Shifty.App
 {
@@ -22,6 +23,7 @@ namespace Shifty.App
         {
             var builder = WebAssemblyHostBuilder.CreateDefault(args);
             builder.RootComponents.Add<App>("#app");
+            builder.Services.AddMudExtensions();
             ConfigureServices(builder.Services, builder.Configuration);
 
             await builder.Build().RunAsync();

--- a/Shifty.App/Program.cs
+++ b/Shifty.App/Program.cs
@@ -55,12 +55,14 @@ namespace Shifty.App
             services.AddScoped<IAccountRepository, AccountRepository>();
             services.AddScoped<IVoucherRepository, VoucherRepository>();
             services.AddScoped<IProductRepository, ProductRepository>();
+            services.AddScoped<IMenuItemRepository, MenuItemRepository>();
             services.AddScoped<CustomAuthStateProvider>();
             services.AddScoped<AuthenticationStateProvider>(s => s.GetService<CustomAuthStateProvider>());
             services.AddScoped<IAuthenticationService, AuthenticationService>();
             services.AddScoped<IVoucherService, VoucherService>();
             services.AddScoped<IProductService, ProductService>();
             services.AddScoped<IUserService, UserService>();
+            services.AddScoped<IMenuItemService, MenuItemService>();
             services.AddScoped<RequestAuthenticationHandler>();
 
             services.AddMudServices(config =>

--- a/Shifty.App/Repositories/IMenuItemRepository.cs
+++ b/Shifty.App/Repositories/IMenuItemRepository.cs
@@ -9,5 +9,7 @@ namespace Shifty.App.Repositories
     public interface IMenuItemRepository
     {
         public Task<Try<System.Collections.Generic.IEnumerable<MenuItemResponse>>> GetMenuItems();
+        public Task<Try<MenuItemResponse>> UpdateMenuItem(UpdateMenuItemRequest menuItem, int menuItemId);
+        public Task<Try<MenuItemResponse>> AddMenuItem(AddMenuItemRequest menuItem);
     }
 }

--- a/Shifty.App/Repositories/IMenuItemRepository.cs
+++ b/Shifty.App/Repositories/IMenuItemRepository.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using LanguageExt;
+using LanguageExt.Common;
+using Shifty.Api.Generated.AnalogCoreV1;
+using Shifty.Api.Generated.AnalogCoreV2;
+
+namespace Shifty.App.Repositories
+{
+    public interface IMenuItemRepository
+    {
+        public Task<Try<System.Collections.Generic.IEnumerable<MenuItemResponse>>> GetMenuItems();
+    }
+}

--- a/Shifty.App/Repositories/IProductRepository.cs
+++ b/Shifty.App/Repositories/IProductRepository.cs
@@ -8,8 +8,8 @@ namespace Shifty.App.Repositories
 {
     public interface IProductRepository
     {
-        Task<Try<ChangedProductResponse>> AddProduct(AddProductRequest addProductRequest);
+        Task<Try<ProductResponse>> AddProduct(AddProductRequest addProductRequest);
         public Task<Try<System.Collections.Generic.IEnumerable<ProductResponse>>> GetProducts();
-        Task<Try<ChangedProductResponse>> UpdateProduct(UpdateProductRequest product);
+        Task<Try<ProductResponse>> UpdateProduct(int productId, UpdateProductRequest product);
     }
 }

--- a/Shifty.App/Repositories/MenuItemRepository.cs
+++ b/Shifty.App/Repositories/MenuItemRepository.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using LanguageExt;
+using LanguageExt.Common;
+using Shifty.Api.Generated.AnalogCoreV1;
+using Shifty.Api.Generated.AnalogCoreV2;
+using Shifty.App.Services;
+using static LanguageExt.Prelude;
+
+namespace Shifty.App.Repositories
+{
+    public class MenuItemRepository : IMenuItemRepository
+    {
+        private readonly AnalogCoreV2 _client;
+
+        public MenuItemRepository(AnalogCoreV2 client)
+        {
+            _client = client;
+        }
+
+        public async Task<Try<IEnumerable<MenuItemResponse>>> GetMenuItems()
+        {
+            return await TryAsync(async () => (await _client.ApiV2MenuitemsGetAsync()).AsEnumerable());
+        }
+
+        public async Task<Try<MenuItemResponse>> UpdateMenuItem(UpdateMenuItemRequest menuItem, int menuItemId)
+        {
+            return await TryAsync(async () => await _client.ApiV2MenuitemsPutAsync(id: menuItemId, menuItem: menuItem));
+        }
+
+        public async Task<Try<MenuItemResponse>> AddMenuItem(AddMenuItemRequest menuItem)
+        {
+            return await TryAsync(async () => await _client.ApiV2MenuitemsPostAsync(menuItem));
+        }
+    }
+}

--- a/Shifty.App/Repositories/ProductRepository.cs
+++ b/Shifty.App/Repositories/ProductRepository.cs
@@ -20,14 +20,14 @@ namespace Shifty.App.Repositories
             _client = client;
         }
 
-        public async Task<Try<ChangedProductResponse>> AddProduct(AddProductRequest addProductRequest)
+        public async Task<Try<ProductResponse>> AddProduct(AddProductRequest addProductRequest)
         {
             return await TryAsync(async () => await _client.ApiV2ProductsPostAsync(addProductRequest));
         }
 
-        public async Task<Try<ChangedProductResponse>> UpdateProduct(UpdateProductRequest product)
+        public async Task<Try<ProductResponse>> UpdateProduct(int productId, UpdateProductRequest product)
         {
-            return await TryAsync(async () => await _client.ApiV2ProductsPutAsync(product));
+            return await TryAsync(async () => await _client.ApiV2ProductsPutAsync(productId, product));
         }
 
         async Task<Try<IEnumerable<ProductResponse>>> IProductRepository.GetProducts()

--- a/Shifty.App/Services/IMenuItemService.cs
+++ b/Shifty.App/Services/IMenuItemService.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LanguageExt;
+using LanguageExt.Common;
+using Shifty.Api.Generated.AnalogCoreV1;
+using Shifty.Api.Generated.AnalogCoreV2;
+using Shifty.App.DomainModels;
+
+namespace Shifty.App.Services
+{
+    public interface IMenuItemService
+    {
+        /// <summary>
+        /// Gives MenuItems available to user
+        /// </summary>
+        /// <returns>Collection of MenuItems in the form of MenuItemDtos. The Collection is null if an error happens.</returns>
+        Task<Try<IEnumerable<MenuItem>>> GetMenuItems();
+
+        /// <summary>
+        /// Updates a MenuItem
+        /// </summary>
+        /// <param name="MenuItem">The MenuItem request containing the updated MenuItem information</param>
+        /// <param name="id">The id of the MenuItem to update</param>
+        /// <returns>The updated MenuItem</returns>
+        Task<Try<MenuItem>> UpdateMenuItem(UpdateMenuItemRequest MenuItem, int id);
+
+        /// <summary>
+        /// Adds a MenuItem
+        /// </summary>
+        /// <param name="MenuItem">The MenuItem request containing the new MenuItem information</param>
+        /// <returns>The newly created MenuItem</returns>
+        Task<Try<MenuItem>> AddMenuItem(AddMenuItemRequest MenuItem);
+    }
+}

--- a/Shifty.App/Services/IProductService.cs
+++ b/Shifty.App/Services/IProductService.cs
@@ -4,6 +4,7 @@ using LanguageExt;
 using LanguageExt.Common;
 using Shifty.Api.Generated.AnalogCoreV1;
 using Shifty.Api.Generated.AnalogCoreV2;
+using Shifty.App.DomainModels;
 
 namespace Shifty.App.Services
 {
@@ -13,20 +14,20 @@ namespace Shifty.App.Services
         /// Gives products available to user
         /// </summary>
         /// <returns>Collection of products in the form of ProductDtos. The Collection is null if an error happens.</returns>
-        Task<Try<IEnumerable<ProductResponse>>> GetProducts();
+        Task<Try<IEnumerable<Product>>> GetProducts();
 
         /// <summary>
         /// Updates a product
         /// </summary>
         /// <param name="product">The product request containing the updated product information</param>
         /// <returns>The updated product</returns>
-        Task<Try<ChangedProductResponse>> UpdateProduct(UpdateProductRequest product);
+        Task<Try<Product>> UpdateProduct(Product product, int id);
 
         /// <summary>
         /// Adds a product
         /// </summary>
         /// <param name="product">The product request containing the new product information</param>
         /// <returns>The newly created product</returns>
-        Task<Try<ChangedProductResponse>> AddProduct(AddProductRequest product);
+        Task<Try<Product>> AddProduct(Product product);
     }
 }

--- a/Shifty.App/Services/MenuItemService.cs
+++ b/Shifty.App/Services/MenuItemService.cs
@@ -26,14 +26,14 @@ namespace Shifty.App.Services
         {
             return await _MenuItemRepository
                         .UpdateMenuItem(MenuItem, id)
-                        .Map(mi => DomainModels.MenuItem.FromDto(mi));
+                        .Map(DomainModels.MenuItem.FromDto);
         }
 
         public async Task<Try<MenuItem>> AddMenuItem(AddMenuItemRequest MenuItem)
         {
             return await _MenuItemRepository
                         .AddMenuItem(MenuItem)
-                        .Map(mi => DomainModels.MenuItem.FromDto(mi));
+                        .Map(DomainModels.MenuItem.FromDto);
         }
         
         public async Task<Try<IEnumerable<MenuItem>>> GetMenuItems()
@@ -42,7 +42,7 @@ namespace Shifty.App.Services
                         .GetMenuItems();
 
             return await temp.Map(x => 
-                x.Map(mi => MenuItem.FromDto(mi)));
+                x.Map(MenuItem.FromDto));
         }
     }
 }

--- a/Shifty.App/Services/MenuItemService.cs
+++ b/Shifty.App/Services/MenuItemService.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Blazored.LocalStorage;
+using Components;
+using LanguageExt;
+using LanguageExt.Common;
+using LanguageExt.UnsafeValueAccess;
+using Shifty.Api.Generated.AnalogCoreV1;
+using Shifty.Api.Generated.AnalogCoreV2;
+using Shifty.App.DomainModels;
+using Shifty.App.Repositories;
+
+namespace Shifty.App.Services
+{
+    public class MenuItemService : IMenuItemService
+    {
+        private readonly IMenuItemRepository _MenuItemRepository;
+        
+        public MenuItemService(IMenuItemRepository MenuItemRepository)
+        {
+            _MenuItemRepository = MenuItemRepository;
+        }
+        
+        public async Task<Try<MenuItem>> UpdateMenuItem(UpdateMenuItemRequest MenuItem, int id)
+        {
+            return await _MenuItemRepository
+                        .UpdateMenuItem(MenuItem, id)
+                        .Map(mi => DomainModels.MenuItem.FromDto(mi));
+        }
+
+        public async Task<Try<MenuItem>> AddMenuItem(AddMenuItemRequest MenuItem)
+        {
+            return await _MenuItemRepository
+                        .AddMenuItem(MenuItem)
+                        .Map(mi => DomainModels.MenuItem.FromDto(mi));
+        }
+        
+        public async Task<Try<IEnumerable<MenuItem>>> GetMenuItems()
+        {
+            var temp = _MenuItemRepository
+                        .GetMenuItems();
+
+            return await temp.Map(x => 
+                x.Map(mi => MenuItem.FromDto(mi)));
+        }
+    }
+}

--- a/Shifty.App/Services/ProductService.cs
+++ b/Shifty.App/Services/ProductService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Blazored.LocalStorage;
 using LanguageExt;
@@ -8,6 +9,7 @@ using LanguageExt.UnsafeValueAccess;
 using Shifty.Api.Generated.AnalogCoreV1;
 using Shifty.Api.Generated.AnalogCoreV2;
 using Shifty.App.Authentication;
+using Shifty.App.DomainModels;
 using Shifty.App.Repositories;
 
 namespace Shifty.App.Services
@@ -21,19 +23,46 @@ namespace Shifty.App.Services
             _productRepository = productRepository;
         }
 
-        public async Task<Try<IEnumerable<ProductResponse>>> GetProducts()
+        public async Task<Try<IEnumerable<Product>>> GetProducts()
         {
-            return await _productRepository.GetProducts();
+            Console.WriteLine("I'm in the ProductService.GetProducts() method");
+            return await _productRepository
+                            .GetProducts()
+                            .Map(x => x.Map(p => Product.FromDto(p)));
         }
         
-        public async Task<Try<ChangedProductResponse>> UpdateProduct(UpdateProductRequest product)
+        public async Task<Try<Product>> UpdateProduct(Product product, int id)
         {
-            return await _productRepository.UpdateProduct(product);
+            var productrequest = new UpdateProductRequest(){
+                        Id = id,
+                        Name = product.Name,
+                        Price = product.Price,
+                        Description = product.Description,
+                        AllowedUserGroups = product.AllowedUserGroups.ToList(),
+                        MenuItemIds = product.EligibleMenuItems.Map(x => x.Id).ToList(),
+                        NumberOfTickets = product.NumberOfTickets,
+                        Visible = product.Visible
+            };
+
+            return await _productRepository.UpdateProduct(productrequest)
+                            .Map(p => Product.FromChangedProduct(p, id, false)); // TODO: Fix when UpdateProduct returns IsPerk property
         }
 
-        public async Task<Try<ChangedProductResponse>> AddProduct(AddProductRequest product)
+        public async Task<Try<Product>> AddProduct(Product product)
         {
-            return await _productRepository.AddProduct(product);
+            var productrequest = new AddProductRequest(){
+                        Name = product.Name,
+                        Price = product.Price,
+                        Description = product.Description,
+                        AllowedUserGroups = product.AllowedUserGroups.ToList(),
+                        MenuItemIds = product.EligibleMenuItems.Map(x => x.Id).ToList(),
+                        NumberOfTickets = product.NumberOfTickets,
+                        Visible = product.Visible
+            };
+
+            var changedproduct = await _productRepository.AddProduct(productrequest);
+
+            return changedproduct.Map(p => Product.FromChangedProduct(p, 0, false)); // TODO: Fix when AddProduct no longer returns a ChangedProductResponse 
         }
     }
 }

--- a/Shifty.App/Services/ProductService.cs
+++ b/Shifty.App/Services/ProductService.cs
@@ -25,7 +25,6 @@ namespace Shifty.App.Services
 
         public async Task<Try<IEnumerable<Product>>> GetProducts()
         {
-            Console.WriteLine("I'm in the ProductService.GetProducts() method");
             return await _productRepository
                             .GetProducts()
                             .Map(x => x.Map(p => Product.FromDto(p)));

--- a/Shifty.App/Services/ProductService.cs
+++ b/Shifty.App/Services/ProductService.cs
@@ -1,14 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using Blazored.LocalStorage;
 using LanguageExt;
-using LanguageExt.Common;
-using LanguageExt.UnsafeValueAccess;
-using Shifty.Api.Generated.AnalogCoreV1;
-using Shifty.Api.Generated.AnalogCoreV2;
-using Shifty.App.Authentication;
 using Shifty.App.DomainModels;
 using Shifty.App.Repositories;
 
@@ -32,36 +24,17 @@ namespace Shifty.App.Services
         
         public async Task<Try<Product>> UpdateProduct(Product product, int id)
         {
-            var productrequest = new UpdateProductRequest(){
-                        Id = id,
-                        Name = product.Name,
-                        Price = product.Price,
-                        Description = product.Description,
-                        AllowedUserGroups = product.AllowedUserGroups.ToList(),
-                        MenuItemIds = product.EligibleMenuItems.Map(x => x.Id).ToList(),
-                        NumberOfTickets = product.NumberOfTickets,
-                        Visible = product.Visible
-            };
+            var productrequest = Product.ToUpdateRequest(product);
 
-            return await _productRepository.UpdateProduct(productrequest)
-                            .Map(p => Product.FromChangedProduct(p, id, false)); // TODO: Fix when UpdateProduct returns IsPerk property
+            return await _productRepository.UpdateProduct(id, productrequest)
+                            .Map(p => Product.FromDto(p));
         }
 
         public async Task<Try<Product>> AddProduct(Product product)
         {
-            var productrequest = new AddProductRequest(){
-                        Name = product.Name,
-                        Price = product.Price,
-                        Description = product.Description,
-                        AllowedUserGroups = product.AllowedUserGroups.ToList(),
-                        MenuItemIds = product.EligibleMenuItems.Map(x => x.Id).ToList(),
-                        NumberOfTickets = product.NumberOfTickets,
-                        Visible = product.Visible
-            };
+            var newproduct = await _productRepository.AddProduct(Product.ToAddRequest(product));
 
-            var changedproduct = await _productRepository.AddProduct(productrequest);
-
-            return changedproduct.Map(p => Product.FromChangedProduct(p, 0, false)); // TODO: Fix when AddProduct no longer returns a ChangedProductResponse 
+            return newproduct.Map(p => Product.FromDto(p));
         }
     }
 }

--- a/Shifty.App/Shared/NavMenu.razor
+++ b/Shifty.App/Shared/NavMenu.razor
@@ -1,9 +1,10 @@
 ﻿<MudNavMenu>
     <MudNavLink Href="" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">Home</MudNavLink>
     @if (_user is not null && _user.IsInRole("Board"))
-    {     
+    {
         <MudNavLink Href="Voucher" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Sell">Issue vouchers</MudNavLink>
         <MudNavLink Href="Products" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Outlined.Inventory">Product Management</MudNavLink>
+        <MudNavLink Href="MenuItems" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Outlined.Coffee">Menu Item Management</MudNavLink>
         <MudNavLink Href="Users" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.ManageAccounts">Manage users</MudNavLink>
     }
 </MudNavMenu>

--- a/Shifty.App/Shifty.App.csproj
+++ b/Shifty.App/Shifty.App.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Blazored.LocalStorage" Version="4.2.0" />
     <PackageReference Include="LanguageExt.Core" Version="4.4.0" />
     <PackageReference Include="MudBlazor" Version="6.11.0" />
+    <PackageReference Include="CodeBeam.MudBlazor.Extensions" Version="6.7.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.2" />

--- a/Shifty.App/wwwroot/index.html
+++ b/Shifty.App/wwwroot/index.html
@@ -14,6 +14,7 @@
     />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link href="manifest.webmanifest" rel="manifest" />
+    <link href="_content/CodeBeam.MudBlazor.Extensions/MudExtensions.min.css" rel="stylesheet" />
     <link rel="apple-touch-icon" sizes="192x192" href="icon-192.png" />
     <link rel="apple-touch-icon" sizes="512x512" href="icon-512.png" />
   </head>
@@ -51,5 +52,6 @@
       navigator.serviceWorker.register("service-worker.js");
     </script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="_content/CodeBeam.MudBlazor.Extensions/MudExtensions.min.js"></script>
   </body>
 </html>

--- a/Shifty.GenerateApi/OpenApiSpecs/AnalogCoreV2.json
+++ b/Shifty.GenerateApi/OpenApiSpecs/AnalogCoreV2.json
@@ -17,7 +17,7 @@
   },
   "servers": [
     {
-      "url": "https://core.dev.analogio.dk"
+      "url": "http://localhost:5001"
     }
   ],
   "paths": {
@@ -1362,6 +1362,47 @@
           }
         ]
       }
+    },
+    "/api/v2/webhooks/accounts/user-group": {
+      "put": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Update user groups in bulk",
+        "operationId": "Webhooks_UpdateUserGroups",
+        "requestBody": {
+          "x-name": "request",
+          "description": "The request containing the new user groups",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebhookUpdateUserGroupRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
+        "responses": {
+          "204": {
+            "description": "The user groups were updated"
+          },
+          "401": {
+            "description": "Invalid credentials"
+          },
+          "400": {
+            "description": "Bad request. See explanation"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "apikey": []
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -1721,10 +1762,16 @@
         "description": "Represents a search result",
         "additionalProperties": false,
         "required": [
-          "users",
-          "totalUsers"
+          "totalUsers",
+          "users"
         ],
         "properties": {
+          "totalUsers": {
+            "type": "integer",
+            "description": "The number of users that match the query",
+            "format": "int32",
+            "example": 1
+          },
           "users": {
             "type": "array",
             "description": "The users that match the query",
@@ -1740,12 +1787,6 @@
             "items": {
               "$ref": "#/components/schemas/SimpleUserResponse"
             }
-          },
-          "totalUsers": {
-            "type": "integer",
-            "description": "The number of users that match the query",
-            "format": "int32",
-            "example": 1
           }
         }
       },
@@ -2444,11 +2485,19 @@
       },
       "PaymentDetails": {
         "type": "object",
+        "discriminator": {
+          "propertyName": "discriminator",
+          "mapping": {
+            "MobilePayPaymentDetails": "#/components/schemas/MobilePayPaymentDetails",
+            "FreePurchasePaymentDetails": "#/components/schemas/FreePurchasePaymentDetails"
+          }
+        },
         "x-abstract": true,
         "additionalProperties": false,
         "required": [
           "paymentType",
-          "orderId"
+          "orderId",
+          "discriminator"
         ],
         "properties": {
           "paymentType": {
@@ -2465,6 +2514,9 @@
             "description": "Order id of purchase",
             "minLength": 1,
             "example": "f5cb3e0f-3b9b-4f50-8c4f-a7450f300a5c"
+          },
+          "discriminator": {
+            "type": "string"
           }
         }
       },
@@ -2497,8 +2549,7 @@
             "additionalProperties": false,
             "required": [
               "mobilePayAppRedirectUri",
-              "paymentId",
-              "state"
+              "paymentId"
             ],
             "properties": {
               "mobilePayAppRedirectUri": {
@@ -2512,12 +2563,6 @@
                 "description": "MobilePay Id for a payment",
                 "minLength": 1,
                 "example": "186d2b31-ff25-4414-9fd1-bfe9807fa8b7"
-              },
-              "state": {
-                "type": "string",
-                "description": "MobilePay state",
-                "nullable": true,
-                "example": "Initiated"
               }
             }
           }
@@ -2650,7 +2695,6 @@
         "required": [
           "id",
           "dateCreated",
-          "dateUsed",
           "productId",
           "productName"
         ],
@@ -2852,6 +2896,49 @@
             "description": "The requester of the voucher codes",
             "minLength": 1,
             "example": "John Doe"
+          }
+        }
+      },
+      "WebhookUpdateUserGroupRequest": {
+        "type": "object",
+        "description": "Represents a request to update user groups in bulk",
+        "additionalProperties": false,
+        "required": [
+          "privilegedUsers"
+        ],
+        "properties": {
+          "privilegedUsers": {
+            "type": "array",
+            "description": "List of accounts and their new user groups",
+            "items": {
+              "$ref": "#/components/schemas/AccountUserGroup"
+            }
+          }
+        }
+      },
+      "AccountUserGroup": {
+        "type": "object",
+        "description": "Represents an account user group update",
+        "additionalProperties": false,
+        "required": [
+          "accountId",
+          "userGroup"
+        ],
+        "properties": {
+          "accountId": {
+            "type": "integer",
+            "description": "The account id",
+            "format": "int32",
+            "example": 1
+          },
+          "userGroup": {
+            "description": "The user group",
+            "example": "Barista",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/UserGroup"
+              }
+            ]
           }
         }
       }

--- a/Shifty.GenerateApi/OpenApiSpecs/AnalogCoreV2.json
+++ b/Shifty.GenerateApi/OpenApiSpecs/AnalogCoreV2.json
@@ -1,5 +1,5 @@
 {
-  "x-generator": "NSwag v13.17.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))",
+  "x-generator": "NSwag v14.0.0.0 (NJsonSchema v11.0.0.0 (Newtonsoft.Json v13.0.0.0))",
   "openapi": "3.0.0",
   "info": {
     "title": "Cafe Analog CoffeeCard API",
@@ -17,7 +17,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost:5001"
+      "url": "https://core.dev.analogio.dk"
     }
   ],
   "paths": {
@@ -349,7 +349,8 @@
             "description": "A filter to search by Id, Name or Email. When an empty string is given, all users will be returned",
             "schema": {
               "type": "string",
-              "default": ""
+              "default": "",
+              "nullable": true
             },
             "x-position": 2
           },
@@ -674,6 +675,7 @@
             "name": "id",
             "in": "path",
             "required": true,
+            "description": "Menu item id to update",
             "schema": {
               "type": "integer",
               "format": "int32"
@@ -730,7 +732,8 @@
             "in": "header",
             "description": "Webhook signature",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "nullable": true
             },
             "x-position": 2
           }
@@ -1428,7 +1431,8 @@
         "additionalProperties": false,
         "properties": {
           "message": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -1931,6 +1935,11 @@
             "description": "Name of menu item",
             "minLength": 1,
             "example": "Cappuccino"
+          },
+          "active": {
+            "type": "boolean",
+            "description": "Whether or not this menu item is active",
+            "example": true
           }
         }
       },
@@ -1955,7 +1964,8 @@
         "description": "Initiate an update product request.",
         "additionalProperties": false,
         "required": [
-          "name"
+          "name",
+          "active"
         ],
         "properties": {
           "name": {
@@ -1963,6 +1973,11 @@
             "description": "Gets or sets the updated name of the product.",
             "minLength": 1,
             "example": "Espresso"
+          },
+          "active": {
+            "type": "boolean",
+            "description": "Gets or sets the updated active status of the product.",
+            "example": true
           }
         }
       },
@@ -2429,15 +2444,11 @@
       },
       "PaymentDetails": {
         "type": "object",
-        "discriminator": {
-          "propertyName": "discriminator"
-        },
         "x-abstract": true,
         "additionalProperties": false,
         "required": [
           "paymentType",
-          "orderId",
-          "discriminator"
+          "orderId"
         ],
         "properties": {
           "paymentType": {
@@ -2454,9 +2465,6 @@
             "description": "Order id of purchase",
             "minLength": 1,
             "example": "f5cb3e0f-3b9b-4f50-8c4f-a7450f300a5c"
-          },
-          "discriminator": {
-            "type": "string"
           }
         }
       },
@@ -2479,9 +2487,6 @@
           },
           {
             "type": "object",
-            "discriminator": {
-              "propertyName": "discriminator"
-            },
             "description": "MobilePay Payment details",
             "example": {
               "paymentType": "MobilePay",
@@ -2493,8 +2498,7 @@
             "required": [
               "mobilePayAppRedirectUri",
               "paymentId",
-              "state",
-              "discriminator"
+              "state"
             ],
             "properties": {
               "mobilePayAppRedirectUri": {
@@ -2514,9 +2518,6 @@
                 "description": "MobilePay state",
                 "nullable": true,
                 "example": "Initiated"
-              },
-              "discriminator": {
-                "type": "string"
               }
             }
           }
@@ -2529,23 +2530,12 @@
           },
           {
             "type": "object",
-            "discriminator": {
-              "propertyName": "discriminator"
-            },
             "description": "Payment details for a free purchase",
             "example": {
               "paymentType": "FreeProduct",
               "orderId": "f5cb3e0f-3b9b-4f50-8c4f-a7450f300a5c"
             },
-            "additionalProperties": false,
-            "required": [
-              "discriminator"
-            ],
-            "properties": {
-              "discriminator": {
-                "type": "string"
-              }
-            }
+            "additionalProperties": false
           }
         ]
       },

--- a/Shifty.GenerateApi/OpenApiSpecs/AnalogCoreV2.json
+++ b/Shifty.GenerateApi/OpenApiSpecs/AnalogCoreV2.json
@@ -590,6 +590,132 @@
         ]
       }
     },
+    "/api/v2/menuitems": {
+      "get": {
+        "tags": [
+          "MenuItems"
+        ],
+        "summary": "Returns a list of all menu items",
+        "operationId": "MenuItems_GetAllMenuItems",
+        "responses": {
+          "200": {
+            "description": "Successful request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MenuItemResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "apikey": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "MenuItems"
+        ],
+        "summary": "Adds a menu item",
+        "operationId": "MenuItems_AddMenuItem",
+        "requestBody": {
+          "x-name": "menuItem",
+          "description": "Menu item to add",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddMenuItemRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
+        "responses": {
+          "201": {
+            "description": "Menu item successfully added",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MenuItemResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "apikey": []
+          }
+        ]
+      }
+    },
+    "/api/v2/menuitems/{id}": {
+      "put": {
+        "tags": [
+          "MenuItems"
+        ],
+        "summary": "Updates a menu item",
+        "operationId": "MenuItems_UpdateMenuItem",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "menuItem",
+          "description": "Menu item to update",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMenuItemRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "200": {
+            "description": "Menu item successfully updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MenuItemResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "apikey": []
+          }
+        ]
+      }
+    },
     "/api/v2/mobilepay/webhook": {
       "post": {
         "tags": [
@@ -745,6 +871,61 @@
           },
           "401": {
             "description": "Invalid credentials"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "apikey": []
+          }
+        ]
+      }
+    },
+    "/api/v2/products/{id}": {
+      "get": {
+        "tags": [
+          "Products"
+        ],
+        "summary": "Returns a product with the specified id",
+        "operationId": "Products_GetProduct",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The id of the product to be returned",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid credentials"
+          },
+          "404": {
+            "description": "The product with the specified id could not be found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -962,6 +1143,71 @@
           },
           "401": {
             "description": "Invalid credentials"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "apikey": []
+          }
+        ]
+      }
+    },
+    "/api/v2/tickets/use": {
+      "post": {
+        "tags": [
+          "Tickets"
+        ],
+        "summary": "Uses a ticket (for the given product) on the given menu item",
+        "operationId": "Tickets_UseTicket",
+        "requestBody": {
+          "x-name": "request",
+          "description": "The product id and menu item id to use a ticket for",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UseTicketRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
+        "responses": {
+          "200": {
+            "description": "Successful request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UsedTicketResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid credentials"
+          },
+          "403": {
+            "description": "User has no tickets for the product or the menu item is not eligible for the ticket",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The product or menu item could not be found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -1454,18 +1700,6 @@
       "UserSearchResponse": {
         "type": "object",
         "description": "Represents a search result",
-        "example": {
-          "users": [
-            {
-              "id": 12232,
-              "name": "John Doe",
-              "email": "johndoe@itu.dk",
-              "userGroup": "Barista",
-              "state": "Active"
-            }
-          ],
-          "totalUsers": 1
-        },
         "additionalProperties": false,
         "required": [
           "users",
@@ -1475,7 +1709,15 @@
           "users": {
             "type": "array",
             "description": "The users that match the query",
-            "example": "[\n   {\n     \"id\": 12232,\n     \"name\": \"John Doe\",\n     \"email\": \"johndoe@itu.dk\",\n     \"userGroup\": \"Barista\",\n     \"state\": \"Active\"\n   }\n ],",
+            "example": [
+              {
+                "id": 12232,
+                "name": "John Doe",
+                "email": "johndoe@itu.dk",
+                "userGroup": "Barista",
+                "state": "Active"
+              }
+            ],
             "items": {
               "$ref": "#/components/schemas/SimpleUserResponse"
             }
@@ -1650,6 +1892,65 @@
           "Total"
         ]
       },
+      "MenuItemResponse": {
+        "type": "object",
+        "description": "Represents a menu item that can be redeemed with a ticket",
+        "example": {
+          "id": 1,
+          "name": "Cappuccino"
+        },
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Id of menu item",
+            "format": "int32",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of menu item",
+            "minLength": 1,
+            "example": "Cappuccino"
+          }
+        }
+      },
+      "AddMenuItemRequest": {
+        "type": "object",
+        "description": "Initiate a new menuitem add request.",
+        "additionalProperties": false,
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Gets or sets the name of the product.",
+            "minLength": 1,
+            "example": "Latte"
+          }
+        }
+      },
+      "UpdateMenuItemRequest": {
+        "type": "object",
+        "description": "Initiate an update product request.",
+        "additionalProperties": false,
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Gets or sets the updated name of the product.",
+            "minLength": 1,
+            "example": "Espresso"
+          }
+        }
+      },
       "MobilePayWebhook": {
         "type": "object",
         "description": "MobilePay webhook invocation request \nCode documentation based on MobilePay Developer: Webhooks",
@@ -1720,7 +2021,8 @@
           "name",
           "description",
           "visible",
-          "allowedUserGroups"
+          "allowedUserGroups",
+          "menuItems"
         ],
         "properties": {
           "price": {
@@ -1743,13 +2045,13 @@
             "type": "string",
             "description": "Gets or sets the name of the product.",
             "minLength": 1,
-            "example": "Espresso "
+            "example": "Espresso"
           },
           "description": {
             "type": "string",
             "description": "Gets or sets the description of the product.",
             "minLength": 1,
-            "example": "A homemade espresso from fresh beans "
+            "example": "A homemade espresso from fresh beans"
           },
           "visible": {
             "type": "boolean",
@@ -1759,9 +2061,23 @@
           "allowedUserGroups": {
             "type": "array",
             "description": "Gets or sets the user groups that can access the product.",
-            "example": "Manager, Board ",
+            "example": [
+              "Manager",
+              "Board"
+            ],
             "items": {
               "$ref": "#/components/schemas/UserGroup"
+            }
+          },
+          "menuItems": {
+            "type": "array",
+            "description": "Gets or sets the eligibible menu items for the product.",
+            "example": [
+              "Espresso",
+              "Cappuccino"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/MenuItemResponse"
             }
           }
         }
@@ -1769,24 +2085,15 @@
       "AddProductRequest": {
         "type": "object",
         "description": "Initiate a new product add request.",
-        "example": {
-          "Name": "Latte",
-          "Price": 25,
-          "NumberOfTickets": 10,
-          "Description": "xxx",
-          "Visible": true,
-          "AllowedUserGroups": [
-            "Manager",
-            "Board"
-          ]
-        },
         "additionalProperties": false,
         "required": [
           "price",
           "numberOfTickets",
           "name",
           "description",
-          "allowedUserGroups"
+          "visible",
+          "allowedUserGroups",
+          "menuItemIds"
         ],
         "properties": {
           "price": {
@@ -1809,13 +2116,13 @@
             "type": "string",
             "description": "Gets or sets the name of the product.",
             "minLength": 1,
-            "example": "Latte "
+            "example": "Latte"
           },
           "description": {
             "type": "string",
             "description": "Gets or sets the description of the product.",
             "minLength": 1,
-            "example": "A homemade latte with soy milk "
+            "example": "A homemade latte with soy milk"
           },
           "visible": {
             "type": "boolean",
@@ -1826,9 +2133,24 @@
           "allowedUserGroups": {
             "type": "array",
             "description": "Gets or sets the user groups that can access the product.",
-            "example": "Manager, Board ",
+            "example": [
+              "Manager",
+              "Board"
+            ],
             "items": {
               "$ref": "#/components/schemas/UserGroup"
+            }
+          },
+          "menuItemIds": {
+            "type": "array",
+            "description": "Gets or sets the menu items that are eligible for the product.",
+            "example": [
+              1,
+              2
+            ],
+            "items": {
+              "type": "integer",
+              "format": "int32"
             }
           }
         }
@@ -1836,18 +2158,6 @@
       "UpdateProductRequest": {
         "type": "object",
         "description": "Initiate an update product request.",
-        "example": {
-          "Id": 1,
-          "Price": 150,
-          "NumberOfTickets": 10,
-          "Name": "Espresso",
-          "Description": "A coffee made by forcing steam through ground coffee beans.",
-          "Visible": false,
-          "AllowedUserGroups": [
-            "Manager",
-            "Board"
-          ]
-        },
         "additionalProperties": false,
         "required": [
           "id",
@@ -1855,7 +2165,9 @@
           "numberOfTickets",
           "name",
           "description",
-          "allowedUserGroups"
+          "visible",
+          "allowedUserGroups",
+          "menuItemIds"
         ],
         "properties": {
           "id": {
@@ -1884,13 +2196,13 @@
             "type": "string",
             "description": "Gets or sets the updated name of the product.",
             "minLength": 1,
-            "example": "Espresso "
+            "example": "Espresso"
           },
           "description": {
             "type": "string",
             "description": "Gets or sets the updated description of the product.",
             "minLength": 1,
-            "example": "A homemade espresso from fresh beans "
+            "example": "A homemade espresso from fresh beans"
           },
           "visible": {
             "type": "boolean",
@@ -1901,9 +2213,24 @@
           "allowedUserGroups": {
             "type": "array",
             "description": "Gets or sets the user groups that can access the product.",
-            "example": "Manager, Board ",
+            "example": [
+              "Manager",
+              "Board"
+            ],
             "items": {
               "$ref": "#/components/schemas/UserGroup"
+            }
+          },
+          "menuItemIds": {
+            "type": "array",
+            "description": "Gets or sets the eligible menu items for the product.",
+            "example": [
+              1,
+              2
+            ],
+            "items": {
+              "type": "integer",
+              "format": "int32"
             }
           }
         }
@@ -1919,9 +2246,19 @@
           "description": "Coffee clip card of 10 clips",
           "isPerk": true,
           "visible": true,
-          "AllowedUserGroups": [
+          "allowedUserGroups": [
             "Manager",
             "Board"
+          ],
+          "eligibleMenuItems": [
+            {
+              "id": 1,
+              "name": "Cappuccino"
+            },
+            {
+              "id": 2,
+              "name": "Caffe Latte"
+            }
           ]
         },
         "additionalProperties": false,
@@ -1982,6 +2319,17 @@
             "example": "Manager, Board ",
             "items": {
               "$ref": "#/components/schemas/UserGroup"
+            }
+          },
+          "eligibleMenuItems": {
+            "type": "array",
+            "description": "The menu items that this product can be used on.",
+            "example": [
+              "Cappuccino",
+              "Caffe Latte"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/MenuItemResponse"
             }
           }
         }
@@ -2371,7 +2719,6 @@
       "TicketResponse": {
         "type": "object",
         "description": "Representing a ticket for a product",
-        "example": "{\n    \"id\": 122,\n    \"dateCreated\": \"2022-01-09T21:03:52.2283208Z\",\n    \"dateUsed\": \"2022-01-09T21:03:52.2283208Z\",\n    \"productId\": 1,\n    \"productName: \"Coffee\"\n}",
         "additionalProperties": false,
         "required": [
           "id",
@@ -2412,6 +2759,80 @@
             "description": "Name of product a ticket is for",
             "minLength": 1,
             "example": "Coffee"
+          },
+          "usedOnMenuItemName": {
+            "type": "string",
+            "description": "The name of the menu item that this ticket was used on",
+            "nullable": true,
+            "example": "Cappuccino"
+          }
+        }
+      },
+      "UsedTicketResponse": {
+        "type": "object",
+        "description": "Representing a used ticket for a product",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "dateCreated",
+          "dateUsed",
+          "productName"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Ticket Id",
+            "format": "int32",
+            "example": 122
+          },
+          "dateCreated": {
+            "type": "string",
+            "description": "Issuing date time for ticket in Utc format",
+            "format": "date-time",
+            "minLength": 1,
+            "example": "2022-01-09T21:03:52.2283208Z"
+          },
+          "dateUsed": {
+            "type": "string",
+            "description": "Used date time for ticket in Utc format",
+            "format": "date-time",
+            "minLength": 1,
+            "example": "2022-01-09T21:03:52.2283208Z"
+          },
+          "productName": {
+            "type": "string",
+            "description": "Name of product a ticket is for",
+            "minLength": 1,
+            "example": "Small drink"
+          },
+          "menuItemName": {
+            "type": "string",
+            "description": "Name of the menu item that this ticket was used on",
+            "nullable": true,
+            "example": "Cappuccino"
+          }
+        }
+      },
+      "UseTicketRequest": {
+        "type": "object",
+        "description": "Represents a request to use a ticket.",
+        "additionalProperties": false,
+        "required": [
+          "productId",
+          "menuItemId"
+        ],
+        "properties": {
+          "productId": {
+            "type": "integer",
+            "description": "The id of the product the ticket is for.",
+            "format": "int32",
+            "example": 1
+          },
+          "menuItemId": {
+            "type": "integer",
+            "description": "The id of the menu item to use the ticket on.",
+            "format": "int32",
+            "example": 1
           }
         }
       },

--- a/Shifty.GenerateApi/OpenApiSpecs/AnalogCoreV2.json
+++ b/Shifty.GenerateApi/OpenApiSpecs/AnalogCoreV2.json
@@ -17,7 +17,7 @@
   },
   "servers": [
     {
-      "url": "https://core.dev.analogio.dk"
+      "url": "http://localhost:5001"
     }
   ],
   "paths": {
@@ -773,11 +773,11 @@
         "tags": [
           "Products"
         ],
-        "summary": "Adds a new product to the database.",
+        "summary": "Adds a new product",
         "operationId": "Products_AddProduct",
         "requestBody": {
           "x-name": "addProductRequest",
-          "description": "The request containing the details of the product to be added and allowed user groups.",
+          "description": "The request containing the details of the product to be added and allowed user groups",
           "content": {
             "application/json": {
               "schema": {
@@ -789,52 +789,12 @@
           "x-position": 1
         },
         "responses": {
-          "200": {
-            "description": "The request was successful, and the product was added.",
+          "201": {
+            "description": "The newly added product",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ChangedProductResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          },
-          {
-            "apikey": []
-          }
-        ]
-      },
-      "put": {
-        "tags": [
-          "Products"
-        ],
-        "summary": "Updates a product with the specified changes.",
-        "operationId": "Products_UpdateProduct",
-        "requestBody": {
-          "x-name": "product",
-          "description": "The request containing the changes to be applied to the product.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateProductRequest"
-              }
-            }
-          },
-          "required": true,
-          "x-position": 1
-        },
-        "responses": {
-          "200": {
-            "description": "The request was successful, and the product was updated.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ChangedProductResponse"
+                  "$ref": "#/components/schemas/ProductResponse"
                 }
               }
             }
@@ -884,6 +844,60 @@
       }
     },
     "/api/v2/products/{id}": {
+      "put": {
+        "tags": [
+          "Products"
+        ],
+        "summary": "Updates a product with the specified changes.",
+        "operationId": "Products_UpdateProduct",
+        "parameters": [
+          {
+            "name": "id",
+            "x-originalName": "productId",
+            "in": "path",
+            "required": true,
+            "description": "Product Id",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "product",
+          "description": "The request containing the changes to be applied to the product",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProductRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "200": {
+            "description": "The product was updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "apikey": []
+          }
+        ]
+      },
       "get": {
         "tags": [
           "Products"
@@ -893,6 +907,7 @@
         "parameters": [
           {
             "name": "id",
+            "x-originalName": "productId",
             "in": "path",
             "required": true,
             "description": "The id of the product to be returned",
@@ -2011,230 +2026,6 @@
           }
         }
       },
-      "ChangedProductResponse": {
-        "type": "object",
-        "description": "Represents the product response.",
-        "additionalProperties": false,
-        "required": [
-          "price",
-          "numberOfTickets",
-          "name",
-          "description",
-          "visible",
-          "allowedUserGroups",
-          "menuItems"
-        ],
-        "properties": {
-          "price": {
-            "type": "integer",
-            "description": "Gets or sets the price of the product.",
-            "format": "int32",
-            "maximum": 2147483647.0,
-            "minimum": 0.0,
-            "example": 150
-          },
-          "numberOfTickets": {
-            "type": "integer",
-            "description": "Gets or sets the number of tickets associated with the product.",
-            "format": "int32",
-            "maximum": 2147483647.0,
-            "minimum": 0.0,
-            "example": 5
-          },
-          "name": {
-            "type": "string",
-            "description": "Gets or sets the name of the product.",
-            "minLength": 1,
-            "example": "Espresso"
-          },
-          "description": {
-            "type": "string",
-            "description": "Gets or sets the description of the product.",
-            "minLength": 1,
-            "example": "A homemade espresso from fresh beans"
-          },
-          "visible": {
-            "type": "boolean",
-            "description": "Gets or sets the visibility of the product.",
-            "example": true
-          },
-          "allowedUserGroups": {
-            "type": "array",
-            "description": "Gets or sets the user groups that can access the product.",
-            "example": [
-              "Manager",
-              "Board"
-            ],
-            "items": {
-              "$ref": "#/components/schemas/UserGroup"
-            }
-          },
-          "menuItems": {
-            "type": "array",
-            "description": "Gets or sets the eligibible menu items for the product.",
-            "example": [
-              "Espresso",
-              "Cappuccino"
-            ],
-            "items": {
-              "$ref": "#/components/schemas/MenuItemResponse"
-            }
-          }
-        }
-      },
-      "AddProductRequest": {
-        "type": "object",
-        "description": "Initiate a new product add request.",
-        "additionalProperties": false,
-        "required": [
-          "price",
-          "numberOfTickets",
-          "name",
-          "description",
-          "visible",
-          "allowedUserGroups",
-          "menuItemIds"
-        ],
-        "properties": {
-          "price": {
-            "type": "integer",
-            "description": "Gets or sets the price of the product.",
-            "format": "int32",
-            "maximum": 2147483647.0,
-            "minimum": 0.0,
-            "example": 10
-          },
-          "numberOfTickets": {
-            "type": "integer",
-            "description": "Gets or sets the number of tickets associated with the product.",
-            "format": "int32",
-            "maximum": 2147483647.0,
-            "minimum": 0.0,
-            "example": 5
-          },
-          "name": {
-            "type": "string",
-            "description": "Gets or sets the name of the product.",
-            "minLength": 1,
-            "example": "Latte"
-          },
-          "description": {
-            "type": "string",
-            "description": "Gets or sets the description of the product.",
-            "minLength": 1,
-            "example": "A homemade latte with soy milk"
-          },
-          "visible": {
-            "type": "boolean",
-            "description": "Gets or sets the visibility of the product. Default is true.",
-            "default": true,
-            "example": true
-          },
-          "allowedUserGroups": {
-            "type": "array",
-            "description": "Gets or sets the user groups that can access the product.",
-            "example": [
-              "Manager",
-              "Board"
-            ],
-            "items": {
-              "$ref": "#/components/schemas/UserGroup"
-            }
-          },
-          "menuItemIds": {
-            "type": "array",
-            "description": "Gets or sets the menu items that are eligible for the product.",
-            "example": [
-              1,
-              2
-            ],
-            "items": {
-              "type": "integer",
-              "format": "int32"
-            }
-          }
-        }
-      },
-      "UpdateProductRequest": {
-        "type": "object",
-        "description": "Initiate an update product request.",
-        "additionalProperties": false,
-        "required": [
-          "id",
-          "price",
-          "numberOfTickets",
-          "name",
-          "description",
-          "visible",
-          "allowedUserGroups",
-          "menuItemIds"
-        ],
-        "properties": {
-          "id": {
-            "type": "integer",
-            "description": "Gets or sets the ID of the product to update.",
-            "format": "int32",
-            "example": 1
-          },
-          "price": {
-            "type": "integer",
-            "description": "Gets or sets the updated price of the product.",
-            "format": "int32",
-            "maximum": 2147483647.0,
-            "minimum": 0.0,
-            "example": 10
-          },
-          "numberOfTickets": {
-            "type": "integer",
-            "description": "Gets or sets the updated number of tickets associated with the product.",
-            "format": "int32",
-            "maximum": 2147483647.0,
-            "minimum": 0.0,
-            "example": 5
-          },
-          "name": {
-            "type": "string",
-            "description": "Gets or sets the updated name of the product.",
-            "minLength": 1,
-            "example": "Espresso"
-          },
-          "description": {
-            "type": "string",
-            "description": "Gets or sets the updated description of the product.",
-            "minLength": 1,
-            "example": "A homemade espresso from fresh beans"
-          },
-          "visible": {
-            "type": "boolean",
-            "description": "Gets or sets the updated visibility of the product. Default is true.",
-            "default": true,
-            "example": true
-          },
-          "allowedUserGroups": {
-            "type": "array",
-            "description": "Gets or sets the user groups that can access the product.",
-            "example": [
-              "Manager",
-              "Board"
-            ],
-            "items": {
-              "$ref": "#/components/schemas/UserGroup"
-            }
-          },
-          "menuItemIds": {
-            "type": "array",
-            "description": "Gets or sets the eligible menu items for the product.",
-            "example": [
-              1,
-              2
-            ],
-            "items": {
-              "type": "integer",
-              "format": "int32"
-            }
-          }
-        }
-      },
       "ProductResponse": {
         "type": "object",
         "description": "Represents a purchasable product",
@@ -2330,6 +2121,152 @@
             ],
             "items": {
               "$ref": "#/components/schemas/MenuItemResponse"
+            }
+          }
+        }
+      },
+      "AddProductRequest": {
+        "type": "object",
+        "description": "Initiate a new product add request.",
+        "additionalProperties": false,
+        "required": [
+          "price",
+          "numberOfTickets",
+          "name",
+          "description",
+          "visible",
+          "allowedUserGroups",
+          "menuItemIds"
+        ],
+        "properties": {
+          "price": {
+            "type": "integer",
+            "description": "Gets or sets the price of the product.",
+            "format": "int32",
+            "maximum": 2147483647.0,
+            "minimum": 0.0,
+            "example": 10
+          },
+          "numberOfTickets": {
+            "type": "integer",
+            "description": "Gets or sets the number of tickets associated with the product.",
+            "format": "int32",
+            "maximum": 2147483647.0,
+            "minimum": 0.0,
+            "example": 5
+          },
+          "name": {
+            "type": "string",
+            "description": "Gets or sets the name of the product.",
+            "minLength": 1,
+            "example": "Latte"
+          },
+          "description": {
+            "type": "string",
+            "description": "Gets or sets the description of the product.",
+            "minLength": 1,
+            "example": "A homemade latte with soy milk"
+          },
+          "visible": {
+            "type": "boolean",
+            "description": "Gets or sets the visibility of the product. Default is true.",
+            "default": true,
+            "example": true
+          },
+          "allowedUserGroups": {
+            "type": "array",
+            "description": "Gets or sets the user groups that can access the product.",
+            "example": [
+              "Manager",
+              "Board"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/UserGroup"
+            }
+          },
+          "menuItemIds": {
+            "type": "array",
+            "description": "Gets or sets the menu items that are eligible for the product.",
+            "example": [
+              1,
+              2
+            ],
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        }
+      },
+      "UpdateProductRequest": {
+        "type": "object",
+        "description": "Initiate an update product request.",
+        "additionalProperties": false,
+        "required": [
+          "price",
+          "numberOfTickets",
+          "name",
+          "description",
+          "visible",
+          "allowedUserGroups",
+          "menuItemIds"
+        ],
+        "properties": {
+          "price": {
+            "type": "integer",
+            "description": "Gets or sets the updated price of the product.",
+            "format": "int32",
+            "maximum": 2147483647.0,
+            "minimum": 0.0,
+            "example": 10
+          },
+          "numberOfTickets": {
+            "type": "integer",
+            "description": "Gets or sets the updated number of tickets associated with the product.",
+            "format": "int32",
+            "maximum": 2147483647.0,
+            "minimum": 0.0,
+            "example": 5
+          },
+          "name": {
+            "type": "string",
+            "description": "Gets or sets the updated name of the product.",
+            "minLength": 1,
+            "example": "Espresso"
+          },
+          "description": {
+            "type": "string",
+            "description": "Gets or sets the updated description of the product.",
+            "minLength": 1,
+            "example": "A homemade espresso from fresh beans"
+          },
+          "visible": {
+            "type": "boolean",
+            "description": "Gets or sets the updated visibility of the product. Default is true.",
+            "default": true,
+            "example": true
+          },
+          "allowedUserGroups": {
+            "type": "array",
+            "description": "Gets or sets the user groups that can access the product.",
+            "example": [
+              "Manager",
+              "Board"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/UserGroup"
+            }
+          },
+          "menuItemIds": {
+            "type": "array",
+            "description": "Gets or sets the eligible menu items for the product.",
+            "example": [
+              1,
+              2
+            ],
+            "items": {
+              "type": "integer",
+              "format": "int32"
             }
           }
         }


### PR DESCRIPTION
This change adds menu items to products (Half of #23).

The EditForm on the product manager now has a ComboBox with both textual input (searching) and multiselection in a dropdown to avoid taking up too much space:
![image](https://github.com/AnalogIO/shifty-webapp/assets/95026056/b72caaa8-2b61-49f6-88f9-13e91a53be34)

This PR also addresses breaking changes in the products API from https://github.com/AnalogIO/analog-core/pull/253 which must be merged first.

This PR also includes minor bugfixes:
- When updating a product, changes are instantly reflected in the DataGrid without having to reload the page.
- When adding a new product, the ID returned from the server will be shown as soon as it is retrieved in the DataGrid.