### PR TITLE
Only show visible products in issue voucher section

### DIFF
--- a/Shifty.App/Components/Voucher.razor
+++ b/Shifty.App/Components/Voucher.razor
@@ -121,7 +121,7 @@
 
         result.Match(
             Succ: products => {
-                _products = products;
+                _products = products.Filter<ProductResponse>(p => p.Visible);
                 _voucherForm.Prefix = User.Claims.Single(el => el.Type.Contains("email")).Value[..3].ToUpper();
             },
             Fail: error => {


### PR DESCRIPTION
Without this fix, legacy products will be shown when attempting to issue vouchers (e.g. face masks)