### PR TITLE
Adds unused tickets statistics

### DIFF
--- a/Shifty.App/Components/UnusedTickets.razor
+++ b/Shifty.App/Components/UnusedTickets.razor
@@ -1,0 +1,95 @@
+@namespace Components
+@using System.ComponentModel.DataAnnotations
+@using Shifty.App.Services
+@using Shifty.Api.Generated.AnalogCoreV1
+@using Shifty.Api.Generated.AnalogCoreV2
+@using Shifty.App.DomainModels
+@using Shifty.App.Shared
+@using Shared
+@using LanguageExt.UnsafeValueAccess
+@inject IUnusedTicketsService _unusedTicketsService
+@inject ISnackbar Snackbar
+
+<MudContainer MaxWidth="MaxWidth.Medium" Style="margin-top: 20px;">
+    <MudDataGrid
+        T="UnusedTicket"
+        Items="@Items"
+        Height="500px"
+        FixedFooter>
+        <ToolBarContent>
+            <MudText Typo="Typo.h6">Unused Tickets</MudText>
+            <MudSpacer />
+            @if (_loading)
+            {
+                <LoadingIndicator Height="64px" />
+            }
+            <MudDateRangePicker DateRange="@_queryDateRange" Editable=true DateRangeChanged="LoadUnusedTickets"/>
+        </ToolBarContent>
+        <Columns>
+            <PropertyColumn Property="x => x.ProductId" Title="Product Id" />
+            <PropertyColumn Property="x => x.ProductName" Title="Product Name" AggregateDefinition="_footerLabel"/>
+            <PropertyColumn Property="x => x.TicketsLeft" Title="Unused Tickets" AggregateDefinition="_ticketsLeftSum" />
+            <PropertyColumn Property="x => x.UnusedPurchasesValue" Title="Unused value (DKK)" AggregateDefinition="_valueLeftSum">
+                <CellTemplate>
+                    @context.Item.UnusedPurchasesValue.ToString("0.00")
+                </CellTemplate>
+            </PropertyColumn>
+        </Columns>
+        <NoRecordsContent>No matching records found</NoRecordsContent>
+    </MudDataGrid>
+</MudContainer>
+
+@code
+{
+    private IEnumerable<UnusedTicket> Items;
+    private bool _loading = false;
+    private DateRange _queryDateRange = new(){ Start = DateTime.Today.AddMonths(-1), End = DateTime.Today};
+
+    private async Task LoadUnusedTickets(DateRange queryDateRange)
+    {
+        _loading = true;
+        if (queryDateRange.Start is null || queryDateRange.End is null) return;
+        
+        _queryDateRange.Start = queryDateRange.Start;
+        _queryDateRange.End = queryDateRange.End;
+        var result = await _unusedTicketsService.GetUnusedTickets(queryDateRange.Start.Value, queryDateRange.End.Value);
+
+        result.Match(
+            Succ: res => {
+                Items = res;
+            },
+            Fail: error => {
+                Snackbar.Add(error.Message, Severity.Error);
+                Items = new List<UnusedTicket>();
+            }
+        );
+        _loading = false;
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        _queryDateRange.Start = new(DateTime.Today.Year, 1, 1);
+        _queryDateRange.End = new(DateTime.Today.Year, 12, 31);
+        await LoadUnusedTickets(_queryDateRange);
+    }
+
+    private AggregateDefinition<UnusedTicket> _ticketsLeftSum = new()
+    {
+        Type = AggregateType.Sum
+    };
+
+    private AggregateDefinition<UnusedTicket> _valueLeftSum = new()
+    {
+        CustomAggregate = x => {
+            var sum = x.Sum(t => t.UnusedPurchasesValue);
+            return sum.ToString("0.00");
+        },
+        Type = AggregateType.Custom,
+    };
+
+    private AggregateDefinition<UnusedTicket> _footerLabel = new()
+    {
+        CustomAggregate = x => "Total",
+        Type = AggregateType.Custom,
+    };
+}

--- a/Shifty.App/Components/UnusedTickets.razor
+++ b/Shifty.App/Components/UnusedTickets.razor
@@ -43,7 +43,7 @@
 {
     private IEnumerable<UnusedTicket> Items;
     private bool _loading = false;
-    private DateRange _queryDateRange = new(){ Start = DateTime.Today.AddMonths(-1), End = DateTime.Today};
+    private DateRange _queryDateRange = new(){ Start = new(DateTime.Today.Year, 1, 1), End = new(DateTime.Today.Year, 12, 31)};
 
     private async Task LoadUnusedTickets(DateRange queryDateRange)
     {
@@ -68,8 +68,6 @@
 
     protected override async Task OnInitializedAsync()
     {
-        _queryDateRange.Start = new(DateTime.Today.Year, 1, 1);
-        _queryDateRange.End = new(DateTime.Today.Year, 12, 31);
         await LoadUnusedTickets(_queryDateRange);
     }
 

--- a/Shifty.App/Components/UnusedTickets.razor
+++ b/Shifty.App/Components/UnusedTickets.razor
@@ -50,8 +50,7 @@
         _loading = true;
         if (queryDateRange.Start is null || queryDateRange.End is null) return;
         
-        _queryDateRange.Start = queryDateRange.Start;
-        _queryDateRange.End = queryDateRange.End;
+        _queryDateRange = queryDateRange;
         var result = await _unusedTicketsService.GetUnusedTickets(queryDateRange.Start.Value, queryDateRange.End.Value);
 
         result.Match(

--- a/Shifty.App/Components/UnusedTickets.razor
+++ b/Shifty.App/Components/UnusedTickets.razor
@@ -35,7 +35,7 @@
                 </CellTemplate>
             </PropertyColumn>
         </Columns>
-        <NoRecordsContent>No matching records found</NoRecordsContent>
+        <NoRecordsContent>No records found for the given time period</NoRecordsContent>
     </MudDataGrid>
 </MudContainer>
 

--- a/Shifty.App/Components/UserTable.razor
+++ b/Shifty.App/Components/UserTable.razor
@@ -76,7 +76,7 @@
 
         return result.Match(
             Succ: res => {
-                return new TableData<SimpleUserResponse>(){ Items = res.Users.AsEnumerable(), TotalItems = res.TotalUsers};;
+                return new TableData<SimpleUserResponse>(){ Items = res.Users.AsEnumerable(), TotalItems = res.TotalUsers};
             },
             Fail: error => {
                 Snackbar.Add(error.Message, Severity.Error);

--- a/Shifty.App/DomainModels/UnusedTicket.cs
+++ b/Shifty.App/DomainModels/UnusedTicket.cs
@@ -1,0 +1,24 @@
+using Components;
+using Shifty.Api.Generated.AnalogCoreV2;
+
+namespace Shifty.App.DomainModels
+{
+    public class UnusedTicket
+    {
+        public int ProductId { get; set; }
+        public string ProductName { get; set; }
+        public int TicketsLeft { get; set; }
+        public decimal UnusedPurchasesValue { get; set; }
+        
+        public static UnusedTicket FromDto(UnusedClipsResponse ticket)
+        {
+            return new UnusedTicket()
+            {
+                ProductId = ticket.ProductId,
+                ProductName = ticket.ProductName,
+                TicketsLeft = ticket.TicketsLeft,
+                UnusedPurchasesValue = ticket.UnusedPurchasesValue,
+            };
+        }
+    }
+}

--- a/Shifty.App/Pages/Statistics.razor
+++ b/Shifty.App/Pages/Statistics.razor
@@ -1,0 +1,24 @@
+@page "/Statistics"
+@using Components
+@inject NavigationManager NavManager
+
+@if (_user is not null && _user.IsInRole("Board"))
+{
+    <UnusedTickets /> 
+}
+
+@code {
+    [CascadingParameter] public Task<AuthenticationState> AuthTask { get; set; }
+    private System.Security.Claims.ClaimsPrincipal _user;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthTask;
+        _user = authState.User;
+
+        if (_user is null || !_user.IsInRole("Board"))
+        {
+            NavManager.NavigateTo("/");
+        }
+    }
+}

--- a/Shifty.App/Program.cs
+++ b/Shifty.App/Program.cs
@@ -58,6 +58,7 @@ namespace Shifty.App
             services.AddScoped<IVoucherRepository, VoucherRepository>();
             services.AddScoped<IProductRepository, ProductRepository>();
             services.AddScoped<IMenuItemRepository, MenuItemRepository>();
+            services.AddScoped<IUnusedTicketRepository, UnusedTicketRepository>();
             services.AddScoped<CustomAuthStateProvider>();
             services.AddScoped<AuthenticationStateProvider>(s => s.GetService<CustomAuthStateProvider>());
             services.AddScoped<IAuthenticationService, AuthenticationService>();
@@ -66,6 +67,7 @@ namespace Shifty.App
             services.AddScoped<IMenuItemService, MenuItemService>();
             services.AddScoped<IUserService, UserService>();
             services.AddScoped<IMenuItemService, MenuItemService>();
+            services.AddScoped<IUnusedTicketsService, UnusedTicketsService>();
             services.AddScoped<RequestAuthenticationHandler>();
 
             services.AddMudServices(config =>

--- a/Shifty.App/Repositories/IUnusedTicketRepository.cs
+++ b/Shifty.App/Repositories/IUnusedTicketRepository.cs
@@ -1,0 +1,15 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LanguageExt;
+using LanguageExt.Common;
+using Shifty.Api.Generated.AnalogCoreV1;
+using Shifty.Api.Generated.AnalogCoreV2;
+
+namespace Shifty.App.Repositories
+{
+    public interface IUnusedTicketRepository
+    {
+        Task<Try<IEnumerable<UnusedClipsResponse>>> GetTickets(UnusedClipsRequest unusedClipsRequest);
+    }
+}

--- a/Shifty.App/Repositories/UnusedTicketsRepository.cs
+++ b/Shifty.App/Repositories/UnusedTicketsRepository.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using LanguageExt;
+using Shifty.Api.Generated.AnalogCoreV2;
+using static LanguageExt.Prelude;
+
+namespace Shifty.App.Repositories
+{
+    public class UnusedTicketRepository : IUnusedTicketRepository
+    {
+        private readonly AnalogCoreV2 _client;
+
+        public UnusedTicketRepository(AnalogCoreV2 client)
+        {
+            _client = client;
+        }
+
+        public async Task<Try<IEnumerable<UnusedClipsResponse>>> GetTickets(UnusedClipsRequest unusedClipsRequest)
+        {
+            return await TryAsync(async () => (await _client.ApiV2StatisticsUnusedClipsAsync(unusedClipsRequest)).AsEnumerable());
+        }
+    }
+}

--- a/Shifty.App/Services/IUnusedTicketsService.cs
+++ b/Shifty.App/Services/IUnusedTicketsService.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LanguageExt;
+using LanguageExt.Common;
+using MudBlazor;
+using Shifty.Api.Generated.AnalogCoreV1;
+using Shifty.Api.Generated.AnalogCoreV2;
+using Shifty.App.DomainModels;
+
+namespace Shifty.App.Services
+{
+    public interface IUnusedTicketsService
+    {
+        /// <summary>
+        /// Queries unused tickets
+        /// </summary>
+        /// <param name="from">The first date to retrieve unused tickets from</param>
+        /// <param name="to">The last date to retrieve unused tickets to</param>
+        /// <returns>A list of unused tickets grouped by product</returns>
+        Task<Try<IEnumerable<UnusedTicket>>> GetUnusedTickets(DateTimeOffset from, DateTimeOffset to);
+    }
+}

--- a/Shifty.App/Services/UnusedTicketsService.cs
+++ b/Shifty.App/Services/UnusedTicketsService.cs
@@ -24,7 +24,7 @@ namespace Shifty.App.Services
                                 StartDate = from,
                                 EndDate = to
                             })
-                            .Map(x => x.Map(t => UnusedTicket.FromDto(t)));
+                            .Map(x => x.Map(UnusedTicket.FromDto));
         }
     }
 }

--- a/Shifty.App/Services/UnusedTicketsService.cs
+++ b/Shifty.App/Services/UnusedTicketsService.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LanguageExt;
+using Shifty.Api.Generated.AnalogCoreV2;
+using Shifty.App.DomainModels;
+using Shifty.App.Repositories;
+
+namespace Shifty.App.Services
+{
+    public class UnusedTicketsService : IUnusedTicketsService
+    {
+        private readonly IUnusedTicketRepository _unusedTicketRepository;
+        
+        public UnusedTicketsService(IUnusedTicketRepository unusedTicketRepository)
+        {
+            _unusedTicketRepository = unusedTicketRepository;
+        }
+
+        public async Task<Try<IEnumerable<UnusedTicket>>> GetUnusedTickets(DateTimeOffset from, DateTimeOffset to)
+        {
+            return await _unusedTicketRepository
+                            .GetTickets(new UnusedClipsRequest(){
+                                StartDate = from,
+                                EndDate = to
+                            })
+                            .Map(x => x.Map(t => UnusedTicket.FromDto(t)));
+        }
+    }
+}

--- a/Shifty.App/Shared/NavMenu.razor
+++ b/Shifty.App/Shared/NavMenu.razor
@@ -3,12 +3,16 @@
 
 <MudNavMenu>
     <MudNavLink Href="" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">Home</MudNavLink>
-    @if (_user is not null && _user.IsInRole("Board"))
+    @if (_user is not null && _user.IsInRole("Board") || _user is not null && _user.IsInRole("Manager"))
     {
         <MudNavLink Href="Voucher" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Sell">Issue vouchers</MudNavLink>
+    }
+    @if (_user is not null && _user.IsInRole("Board"))
+    {
         <MudNavLink Href="Products" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Outlined.Inventory">Product Management</MudNavLink>
         <MudNavLink Href="MenuItems" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Outlined.Coffee">Menu Item Management</MudNavLink>
         <MudNavLink Href="Users" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.ManageAccounts">Manage users</MudNavLink>
+        <MudNavLink Href="Statistics" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Analytics">Statistics</MudNavLink>
     }
     <MudDivider />
     <MudNavLink OnClick="_authenticationService.Logout" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Logout">Logout</MudNavLink>

--- a/Shifty.App/Shared/NavMenu.razor
+++ b/Shifty.App/Shared/NavMenu.razor
@@ -3,7 +3,7 @@
 
 <MudNavMenu>
     <MudNavLink Href="" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">Home</MudNavLink>
-    @if (_user is not null && _user.IsInRole("Board") || _user is not null && _user.IsInRole("Manager"))
+    @if (_user is not null && (_user.IsInRole("Board") || _user.IsInRole("Manager")))
     {
         <MudNavLink Href="Voucher" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Sell">Issue vouchers</MudNavLink>
     }

--- a/Shifty.Generated.ApiClient/OpenApiSpecs/AnalogCoreV2.json
+++ b/Shifty.Generated.ApiClient/OpenApiSpecs/AnalogCoreV2.json
@@ -384,6 +384,61 @@
         ]
       }
     },
+    "/api/v2/statistics/unused-clips": {
+      "post": {
+        "tags": [
+          "AdminStatistics"
+        ],
+        "summary": "Sum unused clip cards within a given period per productId",
+        "operationId": "AdminStatistics_GetUnusedClips",
+        "requestBody": {
+          "x-name": "unusedClipsRequest",
+          "description": "Request object containing start and end date of the query",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UnusedClipsRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
+        "responses": {
+          "200": {
+            "description": " Products with tickets that match the criteria ",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UnusedClipsResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": " Invalid credentials ",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "apikey": []
+          }
+        ]
+      }
+    },
     "/api/v2/appconfig": {
       "get": {
         "tags": ["AppConfig"],
@@ -1736,6 +1791,55 @@
         "description": "",
         "x-enumNames": ["Active", "Deleted", "PendingActivition"],
         "enum": ["Active", "Deleted", "PendingActivition"]
+      },
+      "UnusedClipsResponse": {
+        "type": "object",
+        "description": "Initialize a response with unused clips data",
+        "additionalProperties": false,
+        "properties": {
+          "productId": {
+            "type": "integer",
+            "description": "The id of the product",
+            "format": "int32",
+            "example": 1
+          },
+          "productName": {
+            "type": "string",
+            "description": "The name of the product",
+            "example": "Americano "
+          },
+          "ticketsLeft": {
+            "type": "integer",
+            "description": "The number of tickets unused in a purchase",
+            "format": "int32",
+            "example": 8
+          },
+          "unusedPurchasesValue": {
+            "type": "number",
+            "description": "The value of the unused purchases of a given product",
+            "format": "decimal",
+            "example": 40.2
+          }
+        }
+      },
+      "UnusedClipsRequest": {
+        "type": "object",
+        "description": "Initialize a request for data with unused clips.",
+        "additionalProperties": false,
+        "properties": {
+          "startDate": {
+            "type": "string",
+            "description": "The start date of unused tickets query.",
+            "format": "date-time",
+            "example": "2021-02-08"
+          },
+          "endDate": {
+            "type": "string",
+            "description": "The end date of unused tickets query.",
+            "format": "date-time",
+            "example": "2024-02-08"
+          }
+        }
       },
       "AppConfig": {
         "type": "object",


### PR DESCRIPTION
Closes #9 

Adds a page for statistics in general. This is currently restricted to be viewed only by board members.
This pull request also adds the first statistic view: Unused Tickets, which can be filtered between two dates.
Number of tickets and their value is summed in the footer, see below screenshot.

![image](https://github.com/AnalogIO/shifty-webapp/assets/95026056/b7a75889-a326-4edb-ab67-f2d082397c4c)

Also identified https://github.com/AnalogIO/analog-core/pull/278 during development but is not blocked by the PR, as it only relates to the documentation and not the actual code.

Note:
Managers should have access to `/voucher` as the storage crew is the current primary user of this subpage. I forgot to add the voucher link in the navmenu in previous builds so I just included it in this PR.