### PR TITLE
Better loading indicator

### DIFF
--- a/Shifty.App/Components/MenuItems.razor
+++ b/Shifty.App/Components/MenuItems.razor
@@ -10,77 +10,80 @@
 @using Shifty.App.DomainModels
 @using LanguageExt.UnsafeValueAccess
 @using Shifty.App.Repositories
+@using MudExtensions
 @inject ISnackbar Snackbar
 @inject IJSRuntime JSRuntime
 @inject IMenuItemService MenuItemService
 @inject IDialogService DialogService
 
 <MudPaper Elevation="15" Style="margin: 2em; border-radius: 5px;">
-    @if (_loading)
-    {
-        <MudContainer Style="width: 100%; display: flex;">
-            <LoadingIndicator Height="400px" />
-        </MudContainer>
-    }
-    else
-    {
-        <MudDataGrid
-        @ref="_dataGrid"
-        T="MenuItem"
-        Items="@_menuItems"
-        ReadOnly="false"
-        EditTrigger="DataGridEditTrigger.Manual"
-        CommittedItemChanges="@CommittedItemChanges"
-        StartedEditingItem="@((item) => _editingItem = new MenuItem { Id = item.Id, Name = item.Name, Active = item.Active })"
-        FixedHeader="true"
-        Height="calc(100vh - 250px)"
-        RowStyleFunc="@RowStyleFunc"
-        Dense="true"
-        SortMode="MudBlazor.SortMode.None">
-        <Columns>
-            <TemplateColumn Title="Edit">
-                <CellTemplate>
-                    <MudIconButton
-                        Size="@Size.Medium"
-                        Icon="@Icons.Material.Outlined.Edit"
-                        Color="Color.Primary"
-                        OnClick="@context.Actions.StartEditingItemAsync" />
-                </CellTemplate>
-            </TemplateColumn>
-            <PropertyColumn Property="x => x.Id" Title="Id" IsEditable="false" />
-            <PropertyColumn Property="x => x.Name" Title="Name" IsEditable="true" />
-            <PropertyColumn Property="x => x.Active" Title="Active" IsEditable="true" InitialDirection="SortDirection.Descending">
-                <CellTemplate>
-                    @{
-                        if (context.Item.Active)
-                        {
-                            <MudIconButton Size="@Size.Small" Color="Color.Dark" OnClick="@(() => ConfirmActiveToggle(context.Item))"
-                                Icon="@Icons.Material.Filled.Visibility" />
-                        }
-                        else
-                        {
-                            <MudIconButton Size="@Size.Small" Style="@($"color:{Colors.Grey.Default};")"
-                                Icon="@Icons.Material.Filled.VisibilityOff" OnClick="@(() => ConfirmActiveToggle(context.Item))" />
-                        }
-                    }
-                </CellTemplate>
-                <EditTemplate>
-                    <MudSwitch Label="Active" Color="Color.Primary" @bind-Checked="context.Item.Active" />
-                </EditTemplate>
-            </PropertyColumn>
-        </Columns>
-    </MudDataGrid>
+    <MudLoading @bind-Loading="_loading">
+        <LoaderContent>
+            <MudContainer Style="width: 100%; display: flex;">
+                <LoadingIndicator Height="400px" />
+            </MudContainer>
+        </LoaderContent>
+        <ChildContent>
+            <MudDataGrid
+            @ref="_dataGrid"
+            T="MenuItem"
+            Items="@_menuItems"
+            ReadOnly="false"
+            EditTrigger="DataGridEditTrigger.Manual"
+            CommittedItemChanges="@CommittedItemChanges"
+            StartedEditingItem="@((item) => _editingItem = new MenuItem { Id = item.Id, Name = item.Name, Active = item.Active })"
+            FixedHeader="true"
+            Height="calc(100vh - 250px)"
+            RowStyleFunc="@RowStyleFunc"
+            Dense="true"
+            SortMode="MudBlazor.SortMode.None">
+                <Columns>
+                    <TemplateColumn Title="Edit">
+                        <CellTemplate>
+                            <MudIconButton
+                                Size="@Size.Medium"
+                                Icon="@Icons.Material.Outlined.Edit"
+                                Color="Color.Primary"
+                                OnClick="@context.Actions.StartEditingItemAsync" />
+                        </CellTemplate>
+                    </TemplateColumn>
+                    <PropertyColumn Property="x => x.Id" Title="Id" IsEditable="false" />
+                    <PropertyColumn Property="x => x.Name" Title="Name" IsEditable="true" />
+                    <PropertyColumn Property="x => x.Active" Title="Active" IsEditable="true" InitialDirection="SortDirection.Descending">
+                        <CellTemplate>
+                            @{
+                                if (context.Item.Active)
+                                {
+                                    <MudIconButton Size="@Size.Small" Color="Color.Dark" OnClick="@(() => ConfirmActiveToggle(context.Item))"
+                                        Icon="@Icons.Material.Filled.Visibility" />
+                                }
+                                else
+                                {
+                                    <MudIconButton Size="@Size.Small" Style="@($"color:{Colors.Grey.Default};")"
+                                        Icon="@Icons.Material.Filled.VisibilityOff" OnClick="@(() => ConfirmActiveToggle(context.Item))" />
+                                }
+                            }
+                        </CellTemplate>
+                        <EditTemplate>
+                            <MudSwitch Label="Active" Color="Color.Primary" @bind-Checked="context.Item.Active" />
+                        </EditTemplate>
+                    </PropertyColumn>
+                </Columns>
+            </MudDataGrid>
+    
+            <MudToolBar>
+                <MudSpacer />
+                <MudButton
+                    Color="Color.Primary"
+                    Variant="Variant.Filled"
+                    EndIcon="@Icons.Material.Outlined.Add"
+                    OnClick="@AddItemToDataGrid">
+                        Add Product
+                </MudButton>
+            </MudToolBar>
+        </ChildContent>
+    </MudLoading>
 
-    <MudToolBar>
-        <MudSpacer />
-        <MudButton
-            Color="Color.Primary"
-            Variant="Variant.Filled"
-            EndIcon="@Icons.Material.Outlined.Add"
-            OnClick="@AddItemToDataGrid">
-                Add Product
-        </MudButton>
-    </MudToolBar>
     }
 </MudPaper>
 

--- a/Shifty.App/Components/ProductManager.razor
+++ b/Shifty.App/Components/ProductManager.razor
@@ -20,115 +20,118 @@
     }
 </style>
 <MudPaper Elevation="15" Style="margin: 2em; border-radius: 5px;">
-    @if (_loading)
-    {
-        <MudContainer Style="width: 100%; display: flex;">
-            <LoadingIndicator Height="400px" />
-        </MudContainer>
-    }
-    <MudDataGrid
-        @ref="_dataGrid"
-        T="Product"
-        Items="@_products"
-        EditMode="DataGridEditMode.Form"
-        ReadOnly="false"
-        StartedEditingItem="@StartedEditingItem"
-        CanceledEditingItem="@CanceledEditingItem"
-        CommittedItemChanges="@CommittedItemChanges"
-        EditTrigger="DataGridEditTrigger.Manual"
-        QuickFilter="e => _showNonvisible || e.Visible"
-        RowStyleFunc="@RowStyleFunc"
-        FixedHeader="true"
-        Height="calc(100vh - 250px)"
-        Dense="true"
-        SortMode="MudBlazor.SortMode.None">
-        <Columns>
-            <TemplateColumn Title="Edit">
-                <CellTemplate>
-                    <MudIconButton
-                        Size="@Size.Medium"
-                        Icon="@Icons.Material.Outlined.Edit"
-                        Color="Color.Primary"
-                        OnClick="@context.Actions.StartEditingItemAsync" />
-                </CellTemplate>
-            </TemplateColumn>
-            <PropertyColumn Property="x => x.Visible" Title="" InitialDirection="SortDirection.Descending">
-                <CellTemplate>
-                    @{
-                        if (context.Item.Visible)
-                        {
-                            <MudIcon Size="@Size.Small" Color="Color.Dark"
-                                Icon="@Icons.Material.Filled.Visibility" />
-                        }
-                        else
-                        {
-                            <MudIcon Size="@Size.Small" Style="@($"color:{Colors.Grey.Default};")"
-                                Icon="@Icons.Material.Filled.VisibilityOff" />
-                        }
-                    }
-                </CellTemplate>
-                <EditTemplate>
-                    <MudSwitch id="first-edit-element" Label="Visible" Color="Color.Primary" @bind-Checked="context.Item.Visible" />
-                </EditTemplate>
-            </PropertyColumn>
-            <PropertyColumn Property="x => x.Id" Title="Id" IsEditable="false" />
-            <PropertyColumn Property="x => x.Name" Title="Name" IsEditable="true" />
-            <PropertyColumn Property="x => x.NumberOfTickets" Title="Tickets" IsEditable="true" />
-            <PropertyColumn Property="x => x.Price" Title="Price" IsEditable="true" />
-            <PropertyColumn Property='x => string.Join(", ", x.AllowedUserGroups.Select(e => e.ToString()))'
-                Title="User groups" IsEditable="true">
-                <EditTemplate>
-                    <MudText Typo="Typo.subtitle1">Visible to:</MudText>
-                    @foreach (var group in Enum.GetValues<UserGroup>())
-                    {
-                        <MudCheckBox Dense="true" Color="Color.Primary" @bind-Checked="UserGroupDict[group]" Value="@group">
-                            @group</MudCheckBox>
-                    }
-                </EditTemplate>
-            </PropertyColumn>
-            <PropertyColumn Property="x => x.IsPerk" Title="Perk?" IsEditable="false">
-                <CellTemplate>
-                    @{
-                        if (context.Item.IsPerk)
-                        {
-                            <MudIcon Style="color:gold;" Icon="@Icons.Material.Filled.Star" Title="IsPerk" />
-                        }
-                        else
-                        {
-                            <MudIcon Icon="@Icons.Material.Filled.StarOutline" Title="IsPerk" />
-                        }
-                    }
-                </CellTemplate>
-            </PropertyColumn>
-            <PropertyColumn Property="x => x.Description" Title="Description" IsEditable="true" />
-            <PropertyColumn Property="x => x.EligibleMenuItems" Title="Eligible menu items" IsEditable="true" Hidden>
-                <EditTemplate>
-                    <MudComboBox
-                        T="MenuItem"
-                        Label="Eligible menu items"
-                        MultiSelection="true"
-                        Editable="true"
-                        @bind-SelectedValues="context.Item.EligibleMenuItems">
-                        @foreach (var mi in _allMenuItems)
-                        {
-                            <MudComboBoxItem Text="@mi.Name" Value="@mi">@mi.Name</MudComboBoxItem>
-                        }
-                    </MudComboBox>
-                </EditTemplate>
-            </PropertyColumn>
-        </Columns>
-    </MudDataGrid>
+    <MudLoading @bind-Loading="_loading">
+        <LoaderContent>
+            <MudContainer Style="width: 100%; display: flex;">
+                <LoadingIndicator Height="400px" />
+            </MudContainer>
+        </LoaderContent>
+        <ChildContent>
+            <MudDataGrid
+                @ref="_dataGrid"
+                T="Product"
+                Items="@_products"
+                EditMode="DataGridEditMode.Form"
+                ReadOnly="false"
+                StartedEditingItem="@StartedEditingItem"
+                CanceledEditingItem="@CanceledEditingItem"
+                CommittedItemChanges="@CommittedItemChanges"
+                EditTrigger="DataGridEditTrigger.Manual"
+                QuickFilter="e => _showNonvisible || e.Visible"
+                RowStyleFunc="@RowStyleFunc"
+                FixedHeader="true"
+                Height="calc(100vh - 250px)"
+                Dense="true"
+                SortMode="MudBlazor.SortMode.None">
+                <Columns>
+                    <TemplateColumn Title="Edit">
+                        <CellTemplate>
+                            <MudIconButton
+                                Size="@Size.Medium"
+                                Icon="@Icons.Material.Outlined.Edit"
+                                Color="Color.Primary"
+                                OnClick="@context.Actions.StartEditingItemAsync" />
+                        </CellTemplate>
+                    </TemplateColumn>
+                    <PropertyColumn Property="x => x.Visible" Title="" InitialDirection="SortDirection.Descending">
+                        <CellTemplate>
+                            @{
+                                if (context.Item.Visible)
+                                {
+                                    <MudIcon Size="@Size.Small" Color="Color.Dark"
+                                        Icon="@Icons.Material.Filled.Visibility" />
+                                }
+                                else
+                                {
+                                    <MudIcon Size="@Size.Small" Style="@($"color:{Colors.Grey.Default};")"
+                                        Icon="@Icons.Material.Filled.VisibilityOff" />
+                                }
+                            }
+                        </CellTemplate>
+                        <EditTemplate>
+                            <MudSwitch id="first-edit-element" Label="Visible" Color="Color.Primary" @bind-Checked="context.Item.Visible" />
+                        </EditTemplate>
+                    </PropertyColumn>
+                    <PropertyColumn Property="x => x.Id" Title="Id" IsEditable="false" />
+                    <PropertyColumn Property="x => x.Name" Title="Name" IsEditable="true" />
+                    <PropertyColumn Property="x => x.NumberOfTickets" Title="Tickets" IsEditable="true" />
+                    <PropertyColumn Property="x => x.Price" Title="Price" IsEditable="true" />
+                    <PropertyColumn Property='x => string.Join(", ", x.AllowedUserGroups.Select(e => e.ToString()))'
+                        Title="User groups" IsEditable="true">
+                        <EditTemplate>
+                            <MudText Typo="Typo.subtitle1">Visible to:</MudText>
+                            @foreach (var group in Enum.GetValues<UserGroup>())
+                            {
+                                <MudCheckBox Dense="true" Color="Color.Primary" @bind-Checked="UserGroupDict[group]" Value="@group">
+                                    @group</MudCheckBox>
+                            }
+                        </EditTemplate>
+                    </PropertyColumn>
+                    <PropertyColumn Property="x => x.IsPerk" Title="Perk?" IsEditable="false">
+                        <CellTemplate>
+                            @{
+                                if (context.Item.IsPerk)
+                                {
+                                    <MudIcon Style="color:gold;" Icon="@Icons.Material.Filled.Star" Title="IsPerk" />
+                                }
+                                else
+                                {
+                                    <MudIcon Icon="@Icons.Material.Filled.StarOutline" Title="IsPerk" />
+                                }
+                            }
+                        </CellTemplate>
+                    </PropertyColumn>
+                    <PropertyColumn Property="x => x.Description" Title="Description" IsEditable="true" />
+                    <PropertyColumn Property="x => x.EligibleMenuItems" Title="Eligible menu items" IsEditable="true" Hidden>
+                        <EditTemplate>
+                            <MudComboBox
+                                T="MenuItem"
+                                Label="Eligible menu items"
+                                MultiSelection="true"
+                                Editable="true"
+                                @bind-SelectedValues="context.Item.EligibleMenuItems">
+                                @foreach (var mi in _allMenuItems)
+                                {
+                                    <MudComboBoxItem Text="@mi.Name" Value="@mi">@mi.Name</MudComboBoxItem>
+                                }
+                            </MudComboBox>
+                        </EditTemplate>
+                    </PropertyColumn>
+                </Columns>
+            </MudDataGrid>
 
-    <MudToolBar>
-        <MudSpacer />
-        <MudButton
-            Color="Color.Primary"
-            Variant="Variant.Filled"
-            EndIcon="@Icons.Material.Outlined.Add"
-            OnClick="@AddItemToDataGrid">
-                Add Product
-        </MudButton>
-    </MudToolBar>
+            <MudToolBar>
+                <MudSpacer />
+                <MudButton
+                    Color="Color.Primary"
+                    Variant="Variant.Filled"
+                    EndIcon="@Icons.Material.Outlined.Add"
+                    OnClick="@AddItemToDataGrid">
+                        Add Product
+                </MudButton>
+            </MudToolBar>
+        </ChildContent>
+    </MudLoading>
 </MudPaper>
 @code
 {

--- a/Shifty.App/Components/UnusedTickets.razor
+++ b/Shifty.App/Components/UnusedTickets.razor
@@ -7,36 +7,41 @@
 @using Shifty.App.Shared
 @using Shared
 @using LanguageExt.UnsafeValueAccess
+@using MudExtensions
 @inject IUnusedTicketsService _unusedTicketsService
 @inject ISnackbar Snackbar
 
 <MudContainer MaxWidth="MaxWidth.Medium" Style="margin-top: 20px;">
-    <MudDataGrid
-        T="UnusedTicket"
-        Items="@Items"
-        Height="500px"
-        FixedFooter>
-        <ToolBarContent>
-            <MudText Typo="Typo.h6">Unused Tickets</MudText>
-            <MudSpacer />
-            @if (_loading)
-            {
-                <LoadingIndicator Height="64px" />
-            }
-            <MudDateRangePicker DateRange="@_queryDateRange" Editable=true DateRangeChanged="LoadUnusedTickets"/>
-        </ToolBarContent>
-        <Columns>
-            <PropertyColumn Property="x => x.ProductId" Title="Product Id" />
-            <PropertyColumn Property="x => x.ProductName" Title="Product Name" AggregateDefinition="_footerLabel"/>
-            <PropertyColumn Property="x => x.TicketsLeft" Title="Unused Tickets" AggregateDefinition="_ticketsLeftSum" />
-            <PropertyColumn Property="x => x.UnusedPurchasesValue" Title="Unused value (DKK)" AggregateDefinition="_valueLeftSum">
-                <CellTemplate>
-                    @context.Item.UnusedPurchasesValue.ToString("0.00")
-                </CellTemplate>
-            </PropertyColumn>
-        </Columns>
-        <NoRecordsContent>No records found for the given time period</NoRecordsContent>
-    </MudDataGrid>
+    <MudPaper Style="padding: 10px">
+        <MudText Typo="Typo.h6">Unused Tickets</MudText>
+        <MudDateRangePicker DateRange="@_queryDateRange" Editable=true DateRangeChanged="LoadUnusedTickets"/>
+        <MudLoading @bind-Loading="_loading">
+            <LoaderContent>
+                <MudContainer Style="width: 100%; display: flex;">
+                    <LoadingIndicator Height="400px" />
+                </MudContainer>
+            </LoaderContent>
+            <ChildContent>
+        <MudDataGrid
+            T="UnusedTicket"
+            Items="@Items"
+            Height="500px"
+            FixedFooter>
+                    <Columns>
+                        <PropertyColumn Property="x => x.ProductId" Title="Product Id" />
+                        <PropertyColumn Property="x => x.ProductName" Title="Product Name" AggregateDefinition="_footerLabel"/>
+                        <PropertyColumn Property="x => x.TicketsLeft" Title="Unused Tickets" AggregateDefinition="_ticketsLeftSum" />
+                        <PropertyColumn Property="x => x.UnusedPurchasesValue" Title="Unused value (DKK)" AggregateDefinition="_valueLeftSum">
+                            <CellTemplate>
+                                @context.Item.UnusedPurchasesValue.ToString("0.00")
+                            </CellTemplate>
+                        </PropertyColumn>
+                    </Columns>
+                    <NoRecordsContent>No records found for the given time period</NoRecordsContent>
+                </MudDataGrid>
+            </ChildContent>
+        </MudLoading>
+    </MudPaper>
 </MudContainer>
 
 @code

--- a/Shifty.App/Components/UserTable.razor
+++ b/Shifty.App/Components/UserTable.razor
@@ -5,63 +5,73 @@
 @using Shifty.Api.Generated.AnalogCoreV2
 @using Shared
 @using LanguageExt.UnsafeValueAccess
+@using MudExtensions
 @inject IUserService _userService
 @inject ISnackbar Snackbar
 
 <MudContainer MaxWidth="MaxWidth.Medium" Style="margin-top: 20px;">
-    <MudTable 
-        T="SimpleUserResponse" 
-        ServerData="@(new Func<TableState, Task<TableData<SimpleUserResponse>>>(LoadUsers))" 
-            @ref="_table"
-            EditTrigger="TableEditTrigger.EditButton"
-            ApplyButtonPosition="TableApplyButtonPosition.End"
-            EditButtonPosition="TableEditButtonPosition.End"
-            CanCancelEdit="true"
-            RowEditCancel="ResetUserOnCancel"
-            RowEditCommit="UpdateUserGroup"
-            RowEditPreview="BackupUser"
-            IsEditRowSwitchingBlocked="true">
-        <ToolBarContent>
-            <MudText Typo="Typo.h6">Users</MudText>
-            <MudSpacer />
-            <MudTextField 
-                T="string"
-                ValueChanged="@(s => OnSearch(s))" 
-                Placeholder="Search" 
-                Adornment="Adornment.Start" 
-                AdornmentIcon="Icons.Material.Filled.Search" 
-                IconSize="Size.Medium" />
-        </ToolBarContent>
-        <HeaderContent>
-            <MudTh>Id</MudTh>
-            <MudTh>Name</MudTh>
-            <MudTh>Email</MudTh>
-            <MudTh>UserGroup</MudTh>
-        </HeaderContent>
-        <RowTemplate>
-            <MudTd DataLabel="Id">@context.Id</MudTd>
-            <MudTd DataLabel="Name">@context.Name</MudTd>
-            <MudTd DataLabel="Email">@context.Email</MudTd>
-            <MudTd DataLabel="UserGroup">@context.UserGroup</MudTd>
-        </RowTemplate>
-        <RowEditingTemplate>
-            <MudTd DataLabel="Id">@context.Id</MudTd>
-            <MudTd DataLabel="Name">@context.Name</MudTd>
-            <MudTd DataLabel="Email">@context.Email</MudTd>
-            <MudTd DataLabel="UserGroup">
-                <MudSelect T="UserGroup" Label="UserGroup" @bind-Value="context.UserGroup">
-                    @foreach (var group in Enum.GetValues<UserGroup>()) {
-                        <MudSelectItem T="UserGroup" Value="@group">@group</MudSelectItem>    
-                    }
-                </MudSelect>
-            </MudTd>
-        </RowEditingTemplate>
-        <NoRecordsContent>No matching records found</NoRecordsContent>
-        <PagerContent><MudTablePager /></PagerContent>
-        <EditButtonContent Context="button">
-            <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Edit" OnClick="@button.ButtonAction" Disabled="@button.ButtonDisabled" />
-        </EditButtonContent>
-    </MudTable>
+    <MudPaper Style="padding: 10px">
+        <MudText Typo="Typo.h6">Users</MudText>
+        <MudSpacer />
+        <MudTextField 
+            T="string"
+            ValueChanged="@(s => OnSearch(s))" 
+            Placeholder="Search" 
+            Adornment="Adornment.Start" 
+            AdornmentIcon="Icons.Material.Filled.Search" 
+            IconSize="Size.Medium" />
+        <MudLoading @bind-Loading="_loading">
+            <LoaderContent>
+                <MudContainer Style="width: 100%; display: flex;">
+                    <LoadingIndicator Height="400px" />
+                </MudContainer>
+            </LoaderContent>
+            <ChildContent>
+                <MudTable 
+                    T="SimpleUserResponse" 
+                    ServerData="@(new Func<TableState, Task<TableData<SimpleUserResponse>>>(LoadUsers))" 
+                        @ref="_table"
+                        EditTrigger="TableEditTrigger.EditButton"
+                        ApplyButtonPosition="TableApplyButtonPosition.End"
+                        EditButtonPosition="TableEditButtonPosition.End"
+                        CanCancelEdit="true"
+                        RowEditCancel="ResetUserOnCancel"
+                        RowEditCommit="UpdateUserGroup"
+                        RowEditPreview="BackupUser"
+                        IsEditRowSwitchingBlocked="true">
+                    <HeaderContent>
+                        <MudTh>Id</MudTh>
+                        <MudTh>Name</MudTh>
+                        <MudTh>Email</MudTh>
+                        <MudTh>UserGroup</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Id">@context.Id</MudTd>
+                        <MudTd DataLabel="Name">@context.Name</MudTd>
+                        <MudTd DataLabel="Email">@context.Email</MudTd>
+                        <MudTd DataLabel="UserGroup">@context.UserGroup</MudTd>
+                    </RowTemplate>
+                    <RowEditingTemplate>
+                        <MudTd DataLabel="Id">@context.Id</MudTd>
+                        <MudTd DataLabel="Name">@context.Name</MudTd>
+                        <MudTd DataLabel="Email">@context.Email</MudTd>
+                        <MudTd DataLabel="UserGroup">
+                            <MudSelect T="UserGroup" Label="UserGroup" @bind-Value="context.UserGroup">
+                                @foreach (var group in Enum.GetValues<UserGroup>()) {
+                                    <MudSelectItem T="UserGroup" Value="@group">@group</MudSelectItem>    
+                                }
+                            </MudSelect>
+                        </MudTd>
+                    </RowEditingTemplate>
+                    <NoRecordsContent>No matching records found</NoRecordsContent>
+                    <PagerContent><MudTablePager /></PagerContent>
+                    <EditButtonContent Context="button">
+                        <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Edit" OnClick="@button.ButtonAction" Disabled="@button.ButtonDisabled" />
+                    </EditButtonContent>
+                </MudTable>
+            </ChildContent>
+        </MudLoading>
+    </MudPaper>
 </MudContainer>
 
 @code
@@ -69,11 +79,13 @@
     private MudTable<SimpleUserResponse> _table;
     private string searchString = "";
     UserGroup UserGroupBeforeEdit;
+    private bool _loading = false;
 
     private async Task<TableData<SimpleUserResponse>> LoadUsers(TableState state)
     {
+        _loading = true;
         var result = await _userService.SearchUsers(searchString, state.Page, state.PageSize);
-
+        _loading = false;
         return result.Match(
             Succ: res => {
                 return new TableData<SimpleUserResponse>(){ Items = res.Users.AsEnumerable(), TotalItems = res.TotalUsers};

--- a/Shifty.App/Components/Voucher.razor
+++ b/Shifty.App/Components/Voucher.razor
@@ -7,6 +7,7 @@
 @using LanguageExt.UnsafeValueAccess
 @using Shifty.App.Repositories
 @using Shifty.App.DomainModels
+@using MudExtensions
 @inject IProductService _productService
 @inject IVoucherService _voucherService
 @inject ISnackbar Snackbar
@@ -71,25 +72,28 @@
                     </MudButton>
                 </MudCardActions>
             </MudForm>
-            @if (_showProgressBar)
-            {
-                <MudContainer class="d-flex">
-                    <LoadingIndicator Height="100px"/>
-                </MudContainer>
-            }
-            @if (_vouchers is not null)
-            {
-                <MudTextField Text="@_voucherCodes"  
-                            @ref="_multilineReference"
-                            T="string"
-                            Adornment="Adornment.End" 
-                            Style="border-width: 2px; padding: 4px;" 
-                            Outlined="true" 
-                            AdornmentIcon="@Icons.Material.Outlined.ContentCopy"
-                            OnAdornmentClick="@(async () => await CopyToClipboard())" 
-                            Lines="@Math.Min(_vouchers.Count(), 10)" 
-                            ReadOnly=true />
-            }
+            <MudLoading @bind-Loading="_loading">
+                <LoaderContent>
+                    <MudContainer Style="width: 100%; display: flex;">
+                        <LoadingIndicator Height="400px" />
+                    </MudContainer>
+                </LoaderContent>
+                <ChildContent>
+                    @if (_vouchers is not null)
+                    {
+                        <MudTextField Text="@_voucherCodes"  
+                                    @ref="_multilineReference"
+                                    T="string"
+                                    Adornment="Adornment.End" 
+                                    Style="border-width: 2px; padding: 4px;" 
+                                    Outlined="true" 
+                                    AdornmentIcon="@Icons.Material.Outlined.ContentCopy"
+                                    OnAdornmentClick="@(async () => await CopyToClipboard())" 
+                                    Lines="@Math.Min(_vouchers.Count(), 10)" 
+                                    ReadOnly=true />
+                    }
+                </ChildContent>
+            </MudLoading>
         </MudCardContent>
     </MudCard>
 </MudContainer>
@@ -100,7 +104,7 @@
     public System.Security.Claims.ClaimsPrincipal User { get; set; }
     private VoucherForm _voucherForm = new();
     private bool _isFormValid = false;
-    private bool _showProgressBar = false;
+    private bool _loading = false;
     private IEnumerable<Product> _products = new List<Product>();
     private IEnumerable<IssueVoucherResponse> _vouchers;
     private string _voucherCodes;
@@ -146,7 +150,7 @@
 
     private async Task IssueVoucher()
     {
-        _showProgressBar = true;
+        _loading = true;
         _vouchers = null;
         _voucherCodes = null;
         var result = await _voucherService.IssueVouchers(
@@ -158,12 +162,12 @@
 
         result.Match(
             Succ: response => {
-                _showProgressBar = false;
+                _loading = false;
                 _vouchers = response;
                 _voucherCodes = string.Join("\n", _vouchers.Select(issueVoucherResponse => issueVoucherResponse.VoucherCode));
             },
             Fail: ex => {
-                _showProgressBar = false;
+                _loading = false;
                 Snackbar.Add(ex.Message, Severity.Error);
             }
         );


### PR DESCRIPTION
Attempted to fix #39 
However, there are two issues:

1. It only supports `LoaderContent` and `ChildContent`, where the first is what is shown while loading and the latter while not loading. This means that we have to move any input fields outside of our `MudLoading` component if we want to show it all the time (such as input fields, otherwise they will "reload" on input change). I am not a stylist/webdesigner, so this also means some of our pages changes slightly, see screenshots below. 
2. It does not seem to work well with our `MudTable` in our `UserTable` after I "pulled" the input field outside the `MudTable` in order to not have this reload every time we search for something, but after searching for a user it ends up being stuck on the loading icon. Likely, this is because of the `ServerData` not working with the input field outside or something along those lines, but I did not have more time to investigate this.

I like that we can add the loading content thing "prettier" and an if-statement, but I don't think it saves us any complexity. With the below changes in mind, and the differences in code from the previous versions and this, I suggest we consider whether we want to pursue this further. Consider this a quick proof of concept (even though it does not prove 100%), and feel more than free to scratch it if you don't think it adds the right value.

## Changes

Our Statistics page changed from:
![image](https://github.com/AnalogIO/shifty-webapp/assets/95026056/04284482-b6db-4b17-b1c8-890559920ab5)
To:
![image](https://github.com/AnalogIO/shifty-webapp/assets/95026056/08863f78-37e1-4566-bdc6-151a451a27a7)

Our Manage User page changed from:
![image](https://github.com/AnalogIO/shifty-webapp/assets/95026056/2b1a1aeb-21ec-4341-b98d-7cfea4203485)
To:
![image](https://github.com/AnalogIO/shifty-webapp/assets/95026056/e5e1b7cb-e328-45df-9747-05cff4ba714f)
(And still does not work)