### PR TITLE
fix(products): menu item selection in product manager

### DIFF
--- a/Shifty.App/DomainModels/MenuItem.cs
+++ b/Shifty.App/DomainModels/MenuItem.cs
@@ -44,7 +44,6 @@ namespace Shifty.App.DomainModels
                    Id == menuItem.Id;
         }
         
-        // override object.GetHashCode
         public override int GetHashCode()
         {
             return Id.GetHashCode();

--- a/Shifty.App/DomainModels/MenuItem.cs
+++ b/Shifty.App/DomainModels/MenuItem.cs
@@ -2,7 +2,7 @@ using Shifty.Api.Generated.AnalogCoreV2;
 
 namespace Shifty.App.DomainModels
 {
-    public record MenuItem {
+    public class MenuItem {
         public int Id { get; init; }
         public string Name { get; set; }
         public bool Active { get; set; }
@@ -31,6 +31,23 @@ namespace Shifty.App.DomainModels
                 Name = menuItem.Name,
                 Active = menuItem.Active
             };
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+            
+            return obj is MenuItem menuItem &&
+                   Id == menuItem.Id;
+        }
+        
+        // override object.GetHashCode
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
         }
     }
 }


### PR DESCRIPTION
This PR resolves #47.

Now can correctly display and select menu items in the product management page.

This is done by implementing equality members on MenuItem